### PR TITLE
Add region hooks and field

### DIFF
--- a/src/components/elements/RegionField.jsx
+++ b/src/components/elements/RegionField.jsx
@@ -7,7 +7,7 @@ function RegionField() {
   return (
     <>
       <label>Region</label>
-      <Field name="category" component="select" className={formStyleClasses.select}>
+      <Field name="region" component="select" className={formStyleClasses.select}>
         <option>All</option>
         { REGION_OPTIONS.map(({ value, label }) => {
           return <option key={value} value={value}>{ label }</option>

--- a/src/hooks/events.js
+++ b/src/hooks/events.js
@@ -65,13 +65,15 @@ export function useSearchEvents() {
     const { search, topic } = searchFilters;
     const startDate = moment(searchFilters.startDate).format('YYYY-MM-DD');
     const endDate = moment(searchFilters.endDate).format('YYYY-MM-DD');
+    const region = searchFilters.region
     const topicQuery = topic ? `,${topic}` : '';
 
     async function fetchSearchEvents() {
       const dateQuery = `start_date__gte=${startDate}&start_date__lte=${endDate}`;
       const fullTextQuery = `search=${search}${topicQuery}`;
+      const regionQuery = region ? `region=${region}` : ''
       const response = await fetch(
-        `${API_URL}/api/v1/events?${fullTextQuery}&${dateQuery}`
+        `${API_URL}/api/v1/events?${fullTextQuery}&${dateQuery}&${regionQuery}`
       );
       const json = await response.json();
       const result = camelcaseKeys(json);


### PR DESCRIPTION
Adding region field in views.py. Walked through the front-end/back-end flow and potentially discovered a bug. Region options are not normalized. The region options in the constants file are all lowercase and hyphened, but in the database, they are capitalized and spaced.

To do:
- [x]  Confirm how to normalize the region options in the backend