### PR TITLE
Add support for paginated event search results.

### DIFF
--- a/src/hooks/events.js
+++ b/src/hooks/events.js
@@ -3,6 +3,7 @@ import camelcaseKeys from 'camelcase-keys';
 import moment from 'moment';
 import { useEffect, useState } from 'react';
 import { arrayifyTags } from 'utils/strings';
+import { parseAPIJSON } from 'utils/api';
 
 export function useEvent(eventId) {
   const [evt, setEvent] = useState();
@@ -44,7 +45,7 @@ export function useFeaturedEvents() {
     async function fetchFeaturedEvents() {
       const response = await fetch(`${API_URL}/api/v1/events?featured=true`);
       const json = await response.json();
-      const result = camelcaseKeys(json);
+      const result = camelcaseKeys(json['results']);
       setFeaturedEvents(result);
     }
     fetchFeaturedEvents();
@@ -76,7 +77,7 @@ export function useSearchEvents() {
         `${API_URL}/api/v1/events?${fullTextQuery}&${dateQuery}&${regionQuery}`
       );
       const json = await response.json();
-      const result = camelcaseKeys(json);
+      const result = parseAPIJSON(json);
       setSearchResultEvents(result.slice(0, 10));
     }
     fetchSearchEvents();

--- a/src/hooks/events.js
+++ b/src/hooks/events.js
@@ -45,7 +45,7 @@ export function useFeaturedEvents() {
     async function fetchFeaturedEvents() {
       const response = await fetch(`${API_URL}/api/v1/events?featured=true`);
       const json = await response.json();
-      const result = camelcaseKeys(json['results']);
+      const result = parseAPIJSON(json);
       setFeaturedEvents(result);
     }
     fetchFeaturedEvents();

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -1,0 +1,13 @@
+import camelcaseKeys from 'camelcase-keys';
+
+export function parseAPIJSON(jsonPayload) {
+  let results;
+
+  if (Array.isArray(jsonPayload)) {
+    results = jsonPayload;
+  } else {
+    results = jsonPayload.results;
+  }
+
+  return camelcaseKeys(results);
+}


### PR DESCRIPTION
Django rest framework returns a different payload for paginated results. This change handles both cases payload types to support backwards compatibility.