### PR TITLE
Implement register link

### DIFF
--- a/src/__tests__/elements/ReviewEventMainSection.test.jsx
+++ b/src/__tests__/elements/ReviewEventMainSection.test.jsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ReviewEventMainSection from 'components/elements/ReviewEventMainSection';
+
+describe('Event map view', () => {
+  it('renders registration link', () => {
+    const event = {
+      eventName: 'Test Event',
+      eventType: 'Test Type',
+      description: 'Test Description',
+      eventUrl: 'https://www.test.com',
+    }
+    
+    render(<ReviewEventMainSection evt={event} />);
+
+    const registrationLink = screen.getByText(/Register/i);
+
+    expect(registrationLink).toHaveAttribute('href', 'https://www.test.com');
+    expect(registrationLink).toHaveAttribute('target', '_blank');
+  });
+});

--- a/src/components/elements/ReviewEventMainSection.jsx
+++ b/src/components/elements/ReviewEventMainSection.jsx
@@ -76,9 +76,14 @@ function ReviewEventMainSection({ evt, editEvent }) {
             <span className="mr-2">LinkedIn</span>
           </div>
 
-          <button className="bg-blue-500 text-white p-2 rounded w-1/3">
+          <a
+            className="bg-blue-500 text-white p-2 rounded w-1/3"
+            href={evt.eventUrl}
+            target="_blank"
+            rel="noreferrer"
+          >
             Register
-          </button>
+          </a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
The link in the main section for the event show page was not wired up to link to the event page. Add logic to open the registration link in a new tab.