### PR TITLE
Fix login redirection login.

### DIFF
--- a/src/__tests__/components/pages/VerifyMagicLinkPage.test.jsx
+++ b/src/__tests__/components/pages/VerifyMagicLinkPage.test.jsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import VerifyMagicLinkPage from 'components/pages/VerifyMagicLinkPage';
+
+jest.mock('hooks/authentication', () => ({
+  useAuth: () => ({
+    currentUser: { isAuthenticated: false },
+    verifyOneTimePassCode: jest.fn(),
+  }),
+}));
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => jest.fn(),
+}));
+
+describe('Verify Magic Link Page', () => {
+  describe('Loading', () => {
+    it('renders loading text', () => {
+      render(
+        <MemoryRouter>
+          <VerifyMagicLinkPage />
+        </MemoryRouter>
+      );
+
+      expect(screen.getByText(/Loading.../i)).toBeInTheDocument();
+    });
+  });
+
+  describe('Errors', () => {
+    beforeEach(() => {
+      require('hooks/authentication').useAuth = () => {
+        return {
+          verifyOneTimePassCode: (token, callback) => callback(false, 'Error message'),
+        }
+      }
+    });
+    
+    it('renders error message', async () => {  
+      render(
+        <MemoryRouter>
+          <VerifyMagicLinkPage />
+        </MemoryRouter>
+      );
+
+      expect(screen.getByText(/Error message/i)).toBeInTheDocument();    
+    });
+  });
+
+  describe('Success', () => {
+    let mockNavigate = jest.fn();
+
+    beforeEach(() => {
+      require('react-router-dom').useNavigate = () => mockNavigate
+
+      require('hooks/authentication').useAuth = () => {
+        return {
+          verifyOneTimePassCode: (token, callback) => callback(true, null),
+        }
+      }
+    });
+    
+    it('navigates to root page', async () => {  
+      render(
+        <MemoryRouter>
+          <VerifyMagicLinkPage />
+        </MemoryRouter>
+      );
+
+      expect(screen.getByText(/Success!/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/pages/VerifyMagicLinkPage.jsx
+++ b/src/components/pages/VerifyMagicLinkPage.jsx
@@ -24,7 +24,7 @@ function VerifyMagicLinkPage() {
   // TODO: Clean up loading and error states here.
 
   if (loading) return <div>Loading...</div>
-  if (pageError) return <div>{ pageError}</div>
+  if (pageError) return <div>{ pageError }</div>
 
   return <div>Success!</div>
 }

--- a/src/components/pages/VerifyMagicLinkPage.jsx
+++ b/src/components/pages/VerifyMagicLinkPage.jsx
@@ -1,8 +1,10 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useAuth } from 'hooks/authentication';
 
 function VerifyMagicLinkPage() {
+  const [loading, setLoading] = useState(true);
+  const [pageError, setPageError] = useState();
   const { token } = useParams();
   const navigate = useNavigate();
   const auth = useAuth();
@@ -10,18 +12,21 @@ function VerifyMagicLinkPage() {
   useEffect(() => {
     auth.verifyOneTimePassCode(token, (success, error) => {
       if (success) {
-        navigate('/events/new');
+        setLoading(false);
+        navigate('/');
       } else {
-        window.alert(error);
+        setLoading(false);
+        setPageError(error);
       }
     });
-  }, [token, auth, navigate]);
+  }, []);
 
-  return (
-    <div className="container mx-auto p-40 text-center">
-      Loading...
-    </div>
-  )
+  // TODO: Clean up loading and error states here.
+
+  if (loading) return <div>Loading...</div>
+  if (pageError) return <div>{ pageError}</div>
+
+  return <div>Success!</div>
 }
 
 export default VerifyMagicLinkPage;


### PR DESCRIPTION
## Ticket Description
Addresses the first task listed in  https://github.com/data-umbrella/event-board-web/issues/140

## Description of Changes
Updates the VerifyMagicLinkPage `event-board-web/src/components/pages/VerifyMagicLinkPage.jsx` to redirect users to the home page after successful login.

This PR adds some minor improvements to the state management and documents entry points for loading and error states. Add some basic component tests.

## Before and After for UI Updates
The only visual changes perceivable in this PR is the the place holder text I added

Before:

We were only rendering the text `Loading...`

After:

- `Loading...`
- `Success!`
- Or a dynamic error rendered in page

## Notes for PR Reviewer

We have another ticket for handling loading states I reopened https://github.com/data-umbrella/event-board-web/issues/43. Thinking we should handle adding a spinner as a separate PR.

## For PR Reviewer
- [x] Does this file change the yarn.lock, package.json or package-lock.json file? If so, why? 
- [x] If this pr contains mobile and desktop changes, did you test on IphoneXr and desktop views?
- [x] Does this file match the related tickets linked Figma file, or does it pass the visual smell test?
- [x] If this file contains javascript, does the javascript pass the smell test?
- [ ] If you don't feel super confident in your review, did you assign someone more senior to double check?

