### PR TITLE
Temporarily hide weekly digest nav link.

### DIFF
--- a/src/__tests__/elements/NavigationBar.test.jsx
+++ b/src/__tests__/elements/NavigationBar.test.jsx
@@ -33,7 +33,7 @@ describe('Navigation bar', () => {
       );
 
       expect(screen.getByText(/Event Calendar/i).href).toMatch('/events/calendar');
-      expect(screen.getByText(/Weekly Digest/i).href).toMatch('/events/weekly-digest');
+      // expect(screen.getByText(/Weekly Digest/i).href).toMatch('/events/weekly-digest');
       expect(screen.getByText(/Data Umbrella/i).href).toMatch('www.dataumbrella.org');
       expect(screen.getByText(/Sponsors/i).href).toMatch('/sponsors');
       expect(screen.getByText(/Sign In/i).href).toMatch('/sign-in');

--- a/src/__tests__/elements/NavigationBar.test.jsx
+++ b/src/__tests__/elements/NavigationBar.test.jsx
@@ -33,6 +33,7 @@ describe('Navigation bar', () => {
       );
 
       expect(screen.getByText(/Event Calendar/i).href).toMatch('/events/calendar');
+      // TODO: Uncomment when weekly digest is implement.
       // expect(screen.getByText(/Weekly Digest/i).href).toMatch('/events/weekly-digest');
       expect(screen.getByText(/Data Umbrella/i).href).toMatch('www.dataumbrella.org');
       expect(screen.getByText(/Sponsors/i).href).toMatch('/sponsors');

--- a/src/constants/navbar.js
+++ b/src/constants/navbar.js
@@ -1,7 +1,7 @@
 export const NAVBAR_EVENT_OPTIONS = [
   { label: 'Event Calendar', value: 'event-calendar', route: '/events/calendar' },
   { label: 'Post Event', value: 'post-event', route: '/events/new' },
-  { label: 'Weekly Digest', value: 'weekly-digest', route: '/events/weekly-digest' },
+  // { label: 'Weekly Digest', value: 'weekly-digest', route: '/events/weekly-digest' },
 ]
   
 export const NAVBAR_SUPPORT_OPTIONS = [

--- a/src/constants/navbar.js
+++ b/src/constants/navbar.js
@@ -1,6 +1,7 @@
 export const NAVBAR_EVENT_OPTIONS = [
   { label: 'Event Calendar', value: 'event-calendar', route: '/events/calendar' },
   { label: 'Post Event', value: 'post-event', route: '/events/new' },
+  // TODO: Uncomment when weekly digest is implement.
   // { label: 'Weekly Digest', value: 'weekly-digest', route: '/events/weekly-digest' },
 ]
   


### PR DESCRIPTION
## Ticket Description
PR responding to feedback in https://github.com/data-umbrella/event-board-web/issues/140.


## Description of Changes
Temporarily hiding weekly digest nav link.

## Before and After for UI Updates

Before:
<img width="183" alt="Screen Shot 2022-09-10 at 1 33 46 PM" src="https://user-images.githubusercontent.com/4009178/189500892-5afec82c-166f-4863-93f7-fa632b697ffa.png">

After:
<img width="231" alt="Screen Shot 2022-09-10 at 1 33 38 PM" src="https://user-images.githubusercontent.com/4009178/189500902-93c7e1d3-aad1-49d1-a9fb-15eec26080fa.png">

## Notes for PR Reviewer

Not touching mobile styles to be implemented for this issue https://github.com/data-umbrella/event-board-web/issues/135.

## For PR Reviewer
- [ ] Does this file change the yarn.lock, package.json or package-lock.json file? If so, why?
- [ ] If this pr contains mobile and desktop changes, did you test on IphoneXr and desktop views?
- [ ] Does this file match the related tickets linked figma file, or does it pass the visual smell test?
- [ ] If this file contains javascript, does the javascript pass the smell test?
- [ ] If you don't feel super confident in your review, did you assign someone more senior to double check?

