### PR TITLE
Use default image when provided event image fails to load

### DIFF
--- a/src/components/elements/ReviewEventMainSection.jsx
+++ b/src/components/elements/ReviewEventMainSection.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { imageUrlForEvent } from 'utils/urls';
+import defaultThumbnail from 'assets/thumbnail.png';
 
 const styleClasses = {
   mainSectionContainer: `
@@ -24,6 +25,10 @@ const styleClasses = {
 function ReviewEventMainSection({ evt, editEvent }) {
   const imageUrl = imageUrlForEvent(evt);
 
+  const handleImageError = (event) => {
+    event.target.src = defaultThumbnail;
+  }
+
   return (
     <section>
       <div className="mb-12">
@@ -34,7 +39,7 @@ function ReviewEventMainSection({ evt, editEvent }) {
 
       <div className={styleClasses.mainSectionContainer}>
         <div className={styleClasses.imageContainer}>
-          <img src={imageUrl} className="w-full" alt="logo" />
+          <img src={imageUrl} onError={handleImageError} className="w-full" alt="logo" />
         </div>
 
         <div className="col-span-1">

--- a/src/components/elements/SearchEventCard.jsx
+++ b/src/components/elements/SearchEventCard.jsx
@@ -1,6 +1,7 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { imageUrlForEvent  } from 'utils/urls';
+import defaultThumbnail from 'assets/thumbnail.png';
 
 const styleClasses = {
   searchEventCard: `
@@ -22,32 +23,37 @@ const styleClasses = {
 }
 
 function SearchEventCard({ eventData }) {
-  const imageSrc = imageUrlForEvent(eventData);
+  const [imageUrl, setImageUrl] = useState(imageUrlForEvent(eventData));
+
+  const handleImageError = () => {
+    setImageUrl(defaultThumbnail);
+	};
 
   return (
-    <Link to={`/events/${eventData.id}/details`} className={styleClasses.searchEventCard}>
-      <div
-        className="card-img"
-        style={{ backgroundImage: `url('${imageSrc}')` }}
-      >
-      </div>
+		<Link to={`/events/${eventData.id}/details`} className={styleClasses.searchEventCard}>
+			<div className="card-img" style={{ backgroundImage: `url('${imageUrl}')` }}>
+        {/**
+         * This is a hidden image that loads the same background image for the card,
+         * but allows us to listen for an error event. Upon an error, we can set the
+         * image URL used to the default image.
+         */}
+				<img src={imageUrl} onError={handleImageError} className="w-full" alt="logo" style={{display: "none"}}/>
+			</div>
 
-      <div className="p-8 h-40">
-        <div className={styleClasses.searchEventCardDetail}>
-          <time className="text-neutral-500" dateTime="2018-07-07">
-            {eventData.startDate}
-          </time>
-          <p className="text-right text-neutral-500 pr-2">
-            Free
-          </p>
-        </div>
+			<div className="p-8 h-40">
+				<div className={styleClasses.searchEventCardDetail}>
+					<time className="text-neutral-500" dateTime="2018-07-07">
+						{eventData.startDate}
+					</time>
+					<p className="text-right text-neutral-500 pr-2">Free</p>
+				</div>
 
-        <div>
-          <p className="mt-6 font-bold text-xl">{ eventData.eventName }</p>
-        </div>
-      </div>
-    </Link>
-  )
+				<div>
+					<p className="mt-6 font-bold text-xl">{eventData.eventName}</p>
+				</div>
+			</div>
+		</Link>
+	);
 }
 
 export default SearchEventCard;

--- a/src/components/elements/SearchEventCard.jsx
+++ b/src/components/elements/SearchEventCard.jsx
@@ -1,11 +1,11 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { imageUrlForEvent  } from 'utils/urls';
+import { imageUrlForEvent } from 'utils/urls';
 import moment from 'moment';
 import defaultThumbnail from 'assets/thumbnail.png';
 
 const styleClasses = {
-  searchEventCard: `
+	searchEventCard: `
     block
     border
     border-slate-300
@@ -14,32 +14,32 @@ const styleClasses = {
     dark:bg-du-indigo-900
     bg-white
   `,
-  searchEventThumbnail: `
+	searchEventThumbnail: `
     w-full
     rounded-t
   `,
-  searchEventCardDetail: `
+	searchEventCardDetail: `
     grid
     grid-cols-2
     md:grid-cols-3
-  `
-}
+  `,
+};
 
 function formatDate(date) {
-  if (!date || date === '') return '';
+	if (!date || date === '') return '';
 
-  return moment(date).format('ll');
+	return moment(date).format('ll');
 }
 
 function SearchEventCard({ eventData }) {
-  const [imageUrl, setImageUrl] = useState(imageUrlForEvent(eventData));
-  const startDate = formatDate(eventData.startDate);
+	const [imageUrl, setImageUrl] = useState(imageUrlForEvent(eventData));
+	const startDate = formatDate(eventData.startDate);
 
-  const handleImageError = () => {
-    setImageUrl(defaultThumbnail);
+	const handleImageError = () => {
+		setImageUrl(defaultThumbnail);
 	};
 
-  return (
+	return (
 		<Link to={`/events/${eventData.id}/details`} className={styleClasses.searchEventCard}>
 			<div className="card-img" style={{ backgroundImage: `url('${imageUrl}')` }}>
 				{/**

--- a/src/components/elements/SearchEventCard.jsx
+++ b/src/components/elements/SearchEventCard.jsx
@@ -1,11 +1,11 @@
-import React, { useState } from 'react';
-import { Link } from 'react-router-dom';
-import { imageUrlForEvent } from 'utils/urls';
-import moment from 'moment';
-import defaultThumbnail from 'assets/thumbnail.png';
+import React, { useState } from "react";
+import { Link } from "react-router-dom";
+import { imageUrlForEvent } from "utils/urls";
+import moment from "moment";
+import defaultThumbnail from "assets/thumbnail.png";
 
 const styleClasses = {
-	searchEventCard: `
+  searchEventCard: `
     block
     border
     border-slate-300
@@ -14,11 +14,11 @@ const styleClasses = {
     dark:bg-du-indigo-900
     bg-white
   `,
-	searchEventThumbnail: `
+  searchEventThumbnail: `
     w-full
     rounded-t
   `,
-	searchEventCardDetail: `
+  searchEventCardDetail: `
     grid
     grid-cols-2
     md:grid-cols-3
@@ -26,42 +26,60 @@ const styleClasses = {
 };
 
 function formatDate(date) {
-	if (!date || date === '') return '';
+  if (!date || date === "") return "";
 
-	return moment(date).format('ll');
+  return moment(date).format("ll");
 }
 
 function SearchEventCard({ eventData }) {
-	const [imageUrl, setImageUrl] = useState(imageUrlForEvent(eventData));
-	const startDate = formatDate(eventData.startDate);
+  const [imageUrl, setImageUrl] = useState(imageUrlForEvent(eventData));
+  const startDate = formatDate(eventData.startDate);
 
-	const handleImageError = () => {
-		setImageUrl(defaultThumbnail);
-	};
+  const handleImageError = () => {
+    setImageUrl(defaultThumbnail);
+  };
 
-	return (
-		<Link to={`/events/${eventData.id}/details`} className={styleClasses.searchEventCard}>
-			<div className="card-img" style={{ backgroundImage: `url('${imageUrl}')` }}>
-				{/**
-				 * This is a hidden image that loads the same background image for the card,
-				 * but allows us to listen for an error event. Upon an error, we can set the
-				 * image URL used to the default image.
-				 */}
-				<img src={imageUrl} onError={handleImageError} className="w-full" alt="logo" style={{ display: 'none' }} />
-			</div>
+  return (
+    <Link
+      to={`/events/${eventData.id}/details`}
+      className={styleClasses.searchEventCard}
+    >
+      <div
+        className="card-img"
+        style={{ backgroundImage: `url('${imageUrl}')` }}
+      >
+        {/**
+         * This is a hidden image that loads the same background image for the card,
+         * but allows us to listen for an error event. Upon an error, we can set the
+         * image URL used to the default image.
+         */}
+        <img
+          src={imageUrl}
+          onError={handleImageError}
+          className="w-full"
+          alt="logo"
+          style={{ display: "none" }}
+        />
+      </div>
 
-			<div className="p-8">
-				<div className={styleClasses.searchEventCardDetail}>
-					<time className="text-du-purple-600 dark:text-du-lightPurple md:col-span-2">{startDate}</time>
-					<p className="text-right text-du-purple-600 dark:text-du-lightPurple pr-2 md:col-span-1">Free</p>
-				</div>
+      <div className="p-8">
+        <div className={styleClasses.searchEventCardDetail}>
+          <time className="text-du-purple-600 dark:text-du-lightPurple md:col-span-2">
+            {startDate}
+          </time>
+          <p className="text-right text-du-purple-600 dark:text-du-lightPurple pr-2 md:col-span-1">
+            Free
+          </p>
+        </div>
 
-				<div>
-					<p className="mt-6 font-bold text-base md:text-xl dark:text-du-gray">{eventData.eventName}</p>
-				</div>
-			</div>
-		</Link>
-	);
+        <div>
+          <p className="mt-6 font-bold text-base md:text-xl dark:text-du-gray">
+            {eventData.eventName}
+          </p>
+        </div>
+      </div>
+    </Link>
+  );
 }
 
 export default SearchEventCard;

--- a/src/components/elements/SearchEventCard.jsx
+++ b/src/components/elements/SearchEventCard.jsx
@@ -1,11 +1,8 @@
 import React, { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { imageUrlForEvent  } from 'utils/urls';
-<<<<<<< HEAD
-import defaultThumbnail from 'assets/thumbnail.png';
-=======
 import moment from 'moment';
->>>>>>> main
+import defaultThumbnail from 'assets/thumbnail.png';
 
 const styleClasses = {
   searchEventCard: `
@@ -35,61 +32,36 @@ function formatDate(date) {
 }
 
 function SearchEventCard({ eventData }) {
-<<<<<<< HEAD
   const [imageUrl, setImageUrl] = useState(imageUrlForEvent(eventData));
+  const startDate = formatDate(eventData.startDate);
 
   const handleImageError = () => {
     setImageUrl(defaultThumbnail);
 	};
-=======
-  const imageSrc = imageUrlForEvent(eventData);
-  const startDate = formatDate(eventData.startDate);
->>>>>>> main
 
   return (
 		<Link to={`/events/${eventData.id}/details`} className={styleClasses.searchEventCard}>
 			<div className="card-img" style={{ backgroundImage: `url('${imageUrl}')` }}>
-        {/**
-         * This is a hidden image that loads the same background image for the card,
-         * but allows us to listen for an error event. Upon an error, we can set the
-         * image URL used to the default image.
-         */}
-				<img src={imageUrl} onError={handleImageError} className="w-full" alt="logo" style={{display: "none"}}/>
+				{/**
+				 * This is a hidden image that loads the same background image for the card,
+				 * but allows us to listen for an error event. Upon an error, we can set the
+				 * image URL used to the default image.
+				 */}
+				<img src={imageUrl} onError={handleImageError} className="w-full" alt="logo" style={{ display: 'none' }} />
 			</div>
 
-<<<<<<< HEAD
-			<div className="p-8 h-40">
+			<div className="p-8">
 				<div className={styleClasses.searchEventCardDetail}>
-					<time className="text-neutral-500" dateTime="2018-07-07">
-						{eventData.startDate}
-					</time>
-					<p className="text-right text-neutral-500 pr-2">Free</p>
+					<time className="text-du-purple-600 dark:text-du-lightPurple md:col-span-2">{startDate}</time>
+					<p className="text-right text-du-purple-600 dark:text-du-lightPurple pr-2 md:col-span-1">Free</p>
 				</div>
 
 				<div>
-					<p className="mt-6 font-bold text-xl">{eventData.eventName}</p>
+					<p className="mt-6 font-bold text-base md:text-xl dark:text-du-gray">{eventData.eventName}</p>
 				</div>
 			</div>
 		</Link>
 	);
-=======
-      <div className="p-8">
-        <div className={styleClasses.searchEventCardDetail}>
-          <time className="text-du-purple-600 dark:text-du-lightPurple md:col-span-2">
-            {startDate}
-          </time>
-          <p className="text-right text-du-purple-600 dark:text-du-lightPurple pr-2 md:col-span-1">
-            Free
-          </p>
-        </div>
-
-        <div>
-          <p className="mt-6 font-bold text-base md:text-xl dark:text-du-gray">{ eventData.eventName }</p>
-        </div>
-      </div>
-    </Link>
-  )
->>>>>>> main
 }
 
 export default SearchEventCard;

--- a/src/utils/urls.js
+++ b/src/utils/urls.js
@@ -1,4 +1,4 @@
-import defaultThumbNail from 'assets/thumbnail.png';
+import defaultThumbnail from 'assets/thumbnail.png';
 
 export function isValidURL(string) {
   /* eslint-disable */
@@ -11,6 +11,6 @@ export function imageUrlForEvent(eventData) {
   if (eventData.imageUrl) return eventData.imageUrl;
 
   return eventData.imageFile === '' || !eventData.imageFile
-    ? defaultThumbNail
+    ? defaultThumbnail
     : eventData.imageFile
 }


### PR DESCRIPTION
## Ticket Description

Add default image of data umbrella logo for events that don't have a url.

Closes #180 


## Description of Changes

I utilized the `onerror` callback for HTML images (in React, `onError`) to set the `src` property of the image to the default image if an error occurs. This was straightforward on the Event Details page, but less so on the main Event List page. Since the card images are set via the `background-image` CSS style, we lose access to the `onerror` event callback. To workaround this, I use a hidden image that loads the same image as the background so I can utilize `onerror`. Then when an error occurs, I set the state of the `imageUrl` to our default image.

## Before and After for UI Updates

**Before**:
Even though these events had a `imageUrl` property set, they didn't load due to either being an invalid image or an image that didn't exist (i.e. a 404 error).

Event List
![Screen Shot 2022-09-15 at 5 28 23 PM](https://user-images.githubusercontent.com/5323147/190512195-0dc1e5b2-0190-40bc-997e-3de548ec09f7.jpg)

Event Details
![Screen Shot 2022-09-15 at 5 31 27 PM](https://user-images.githubusercontent.com/5323147/190512516-129d2549-a6e1-466d-873f-87a54c18ef70.jpg)


**After**:
Now the default image is used when an error occurs during loading the originally requested image.

Event List
![Screen Shot 2022-09-15 at 5 28 02 PM](https://user-images.githubusercontent.com/5323147/190512339-7020d0a5-640b-4d60-a6d0-ce1ee13a1a82.jpg)

Event Details
![Screen Shot 2022-09-15 at 5 31 44 PM](https://user-images.githubusercontent.com/5323147/190512562-b831bd7d-f899-4e6d-a154-d2bd223c8e8f.jpg)


## For PR Reviewer
- [ ] Does this file change the yarn.lock, package.json or package-lock.json file? If so, why?
- [ ] If this pr contains mobile and desktop changes, did you test on IphoneXr and desktop views?
- [ ] Does this file match the related tickets linked figma file, or does it pass the visual smell test?
- [ ] If this file contains javascript, does the javascript pass the smell test?
- [ ] If you don't feel super confident in your review, did you assign someone more senior to double check?

