### PR TITLE
Fix mobile nav scroll

### DIFF
--- a/src/components/elements/MobileNav.jsx
+++ b/src/components/elements/MobileNav.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import { useLocation, Link } from "react-router-dom";
 import useDarkMode from 'hooks/dark-mode';
 import Logo from '../../assets/logo.png';
@@ -11,16 +11,23 @@ import { donateURL } from 'constants/donate';
 
 
 function MobileNav() {
-  const [menuOpen, setMenuOpen] = useState(false)
+  const [menuOpen, setMenuOpen] = useState(false);
   const [colorTheme, setTheme] = useDarkMode();
-  
-  const location = useLocation()
+  const location = useLocation();
+  const closeButton = useRef(null);
 
   useEffect(() => {
-    setMenuOpen(false)
+    setMenuOpen(false);
+  }, [location]);
 
-  }, [location])
-
+  useEffect(() => {
+    if (menuOpen) {
+      document.body.classList.add('no-scroll');
+      closeButton.current.scrollIntoView();
+    } else {
+      document.body.classList.remove('no-scroll');
+    }
+  }, [menuOpen]);
 
   return (
     <>
@@ -47,9 +54,16 @@ function MobileNav() {
         </button>
       </div>
       <div className={menuOpen ? 'relative' : 'invisible'}>
-        <div className="dark:bg-du-deepPurple bg-fuchsia-800 z-20 fixed top-0 right-0 pl-8 h-screen text-right w-4/5">
+        <div
+          className="dark:bg-du-deepPurple bg-fuchsia-800 z-20 fixed top-0 right-0 pl-8 h-screen text-right w-4/5"
+          style={{ overflowY: 'scroll' }}
+        >
           <div className="text-white text-2xl grid grid-rows-11 gap-3 place-content-evenly">
-            <button onClick={() => setMenuOpen((prev) => !prev)} className="pb-12 pt-10 text-right">
+            <button
+              className="pb-12 pt-10 text-right"
+              ref={closeButton}
+              onClick={() => setMenuOpen((prev) => !prev)}
+            >
               Close <img className="inline" src={closeSymbol} />
             </button>
             <div>
@@ -75,9 +89,7 @@ function MobileNav() {
         </div>
       </div>
     </>
-  )
-
+  );
 }
 
-
-export default MobileNav
+export default MobileNav;

--- a/src/index.css
+++ b/src/index.css
@@ -23,3 +23,7 @@
 .search-form-gradient {
   background: linear-gradient(180deg, rgba(130, 105, 212, 0.25) 0%, rgba(132, 136, 225, 0.25) 100%);
 }
+
+.no-scroll {
+  overflow: hidden;
+}


### PR DESCRIPTION
## Ticket Description

Fixes #202 

Mobile nav was not scrolling when opened and instead the document body was scrolling. This PR allows the mobile nav to be scrolled and locks the document body to prevent it from being scrolled when the mobile nav is open.

## Description of Changes

Added a base level (`index.css`) CSS class called `no-scroll` that gets applied to the document body when the mobile nav is opened. This class simply sets `overflow` to `hidden` which turns off scrolling.

Then in the `MobileNav` component, I applied logic so that when the `menuOpen` state changes, the `no-scroll` class is added or removed to the document body based on the open state of the menu.

I also insured that the mobile nav is scrolled to the top when opened by applying a `ref` to the close button. This is to make sure the menu opens the same way each time. Without this change, if you scroll down the nav and click on a link (e.g. About Us), the menu closes and you navigate to the link but then if you open the menu again it is partially scrolled down (where ever it was at when you clicked the link).

## Before and After for UI Updates

Before:
Nav bar doesn't scroll, but body content does

https://user-images.githubusercontent.com/5323147/190704353-68a90487-9d95-421c-adb7-51abf384f2f5.mov

After:
Nav bar scrolls and body content is locked in place

https://user-images.githubusercontent.com/5323147/190704767-52df1e52-61d3-42fc-95a8-cbf93c8e5fab.mov

## For PR Reviewer
- [ ] Does this file change the yarn.lock, package.json or package-lock.json file? If so, why?
- [ ] If this pr contains mobile and desktop changes, did you test on IphoneXr and desktop views?
- [ ] Does this file match the related tickets linked figma file, or does it pass the visual smell test?
- [ ] If this file contains javascript, does the javascript pass the smell test?
- [ ] If you don't feel super confident in your review, did you assign someone more senior to double check?

