### PR TITLE
Issue #90 Make org name hyper linked styled text

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "event-board-web",
       "version": "0.1.0",
       "dependencies": {
         "@babel/core": "^7.18.9",

--- a/src/components/elements/EventPlanningDetail.jsx
+++ b/src/components/elements/EventPlanningDetail.jsx
@@ -7,10 +7,10 @@ const styleClasses = {
 function EventPlanningDetail({ label, value, type, name }) {
   if (!value || value === undefined) return
 
-  const formattedValue = type === 'link'
-    ? <a className={styleClasses.link} href={value} target="_blank" rel="noopener noreferrer">
-        { name ? name : value }
-      </a>
+  const formattedValue = type === 'link' ?
+    <a className={styleClasses.link} href={value} target="_blank" rel="noopener noreferrer">
+      { name ? name : value }
+    </a>
     : value
 
   return (

--- a/src/components/elements/EventPlanningDetail.jsx
+++ b/src/components/elements/EventPlanningDetail.jsx
@@ -4,11 +4,13 @@ const styleClasses = {
   link: 'text-blue-600 underline underline-offset-2',
 }
 
-function EventPlanningDetail({ label, value, type }) {
+function EventPlanningDetail({ label, value, type, name }) {
   if (!value || value === undefined) return
 
   const formattedValue = type === 'link'
-    ? <a className={styleClasses.link} href={value}>{ value }</a>
+    ? <a className={styleClasses.link} href={value} target="_blank" rel="noopener noreferrer">
+        { name ? name : value }
+      </a>
     : value
 
   return (

--- a/src/components/elements/EventPlanningSection.jsx
+++ b/src/components/elements/EventPlanningSection.jsx
@@ -60,6 +60,7 @@ function EventPlanningSection({ evt }) {
 
         <EventPlanningDetail
           label="Organization URL"
+          name={evt.organizationName}
           value={evt.organizationUrl}
           type="link"
         />


### PR DESCRIPTION
## Ticket Description
Fixes Issue #90 

Move organization name from header to "EventPlanningSection" right below "Language" detail section.

Organization Name:
Organization Name: <a href="http://linuxfoundation.org>Linux Foundation</a>


## Description of Changes
Update EventPlanningDetail and EventPlanningSection
Adds name parameter

Needed to run npm install for latest package requirements, which is why there is a change in package-lock.json

## Before and After for UI Updates

Before:
<img width="401" alt="image" src="https://user-images.githubusercontent.com/92892101/197294249-00e6fd89-022e-4613-80d0-7af43fd430c4.png">


After:
<img width="386" alt="image" src="https://user-images.githubusercontent.com/92892101/197294188-cbe87a80-45cb-4b5d-bfab-cbc5c56eaf4a.png">


## For PR Reviewer
- [ ] Does this file change the yarn.lock, package.json or package-lock.json file? If so, why?
- [ ] If this pr contains mobile and desktop changes, did you test on IphoneXr and desktop views?
- [ ] Does this file match the related tickets linked figma file, or does it pass the visual smell test?
- [ ] If this file contains javascript, does the javascript pass the smell test?
- [ ] If you don't feel super confident in your review, did you assign someone more senior to double check?

