### PR TITLE
#143 - Search Results Component

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -100,6 +100,11 @@ nav li {
 
 }
 
+.fc-h-event {
+  border: none !important;
+  background-color: none !important;
+}
+
 .card-img {
    background-size: cover;
    background-repeat: no-repeat;

--- a/src/__tests__/utils/dateRange.test.js
+++ b/src/__tests__/utils/dateRange.test.js
@@ -1,0 +1,25 @@
+import { formatDateRangeFromEvent } from 'utils/dates'
+
+describe('formatDateRangeFromEvent', () => {
+  it('returns a correctly formatted date range', () => {
+    const event = 
+      {
+        start: 'September 7, 2022',
+        end: 'September 12, 2022'
+      }
+
+    const result = formatDateRangeFromEvent(event)
+    expect(result).toMatch('September 7 - 12, 2022')
+  })
+
+  it('returns an empty string when start and end date are null', () => {
+    const event = 
+      {
+        start: null,
+        end: null
+      }
+
+    const result = formatDateRangeFromEvent(event)
+    expect(result).toMatch('')
+  })
+})

--- a/src/components/elements/EventCalendarView.jsx
+++ b/src/components/elements/EventCalendarView.jsx
@@ -12,13 +12,18 @@ import { formatEventsForCalendar } from 'utils/events';
 
 function EventContent({ eventInfo }) {
   const navigate = useNavigate();
-
+  
   function handleNavigate () {
     navigate(`/events/${eventInfo.event.id}/details`);
   }
 
+  const eventType = eventInfo.event.extendedProps.type
+  
+  // eslint-disable-next-line no-console
+  console.log(eventType)
+  
   return (
-    <div className="bg-blue-600 w-full" onClick={handleNavigate}>
+    <div className={`bg-event-tags-${eventType} w-full`} onClick={handleNavigate}>
       <div className="text-xs whitespace-normal">
         <b className="mr-1">{eventInfo.timeText}</b>
         { truncate(eventInfo.event.title, 60) }

--- a/src/components/elements/EventCalendarView.jsx
+++ b/src/components/elements/EventCalendarView.jsx
@@ -12,18 +12,14 @@ import { formatEventsForCalendar } from 'utils/events';
 
 function EventContent({ eventInfo }) {
   const navigate = useNavigate();
+  const eventType = eventInfo.event.extendedProps.type
   
   function handleNavigate () {
     navigate(`/events/${eventInfo.event.id}/details`);
   }
 
-  const eventType = eventInfo.event.extendedProps.type
-  
-  // eslint-disable-next-line no-console
-  console.log(eventType)
-  
   return (
-    <div className={`bg-event-tags-${eventType} w-full`} onClick={handleNavigate}>
+    <div className={`bg-event-tags-${eventType} rounded-sm w-full p-2`} onClick={handleNavigate}>
       <div className="text-xs whitespace-normal">
         <b className="mr-1">{eventInfo.timeText}</b>
         { truncate(eventInfo.event.title, 60) }

--- a/src/components/elements/EventCalendarView.jsx
+++ b/src/components/elements/EventCalendarView.jsx
@@ -19,7 +19,7 @@ function EventContent({ eventInfo }) {
   }
 
   return (
-    <div className={`bg-event-tags-${eventType} rounded-sm w-full p-2`} onClick={handleNavigate}>
+    <div className={`bg-event-tags-${eventType} rounded-sm w-full`} onClick={handleNavigate}>
       <div className="text-xs whitespace-normal">
         <b className="mr-1">{eventInfo.timeText}</b>
         { truncate(eventInfo.event.title, 60) }

--- a/src/components/elements/EventsForMonth.jsx
+++ b/src/components/elements/EventsForMonth.jsx
@@ -37,9 +37,9 @@ function DateRange(event) {
   const dateEnd = event.end.split(' ')[0]
 
   if(dateStart === dateEnd) {
-    return <p>{event.start.slice(0, -6) + ' - ' + event.end.substring(event.end.indexOf(' ') + 1)}</p>
+    return <p className="truncate">{event.start.slice(0, -6) + ' - ' + event.end.substring(event.end.indexOf(' ') + 1)}</p>
   }
-  return <p>{event.start + ' - ' + event.end}</p>
+  return <p className="truncate">{event.start + ' - ' + event.end}</p>
 }
 
 
@@ -55,7 +55,8 @@ function EventsForMonth({ events }) {
 
     return (
       <div key={`${evt.id}-${evt.eventName}`} className="border border-gray-300 bg-white dark:bg-du-indigo-900 dark:border-du-lightAqua mb-2 px-2 py-2 rounded">
-        <div className="flex place-content-between">
+        {/* <div className="flex place-content-between"> */}
+        <div className="grid grid-cols-3 sm:grid-cols-4">
           <Link
             to={`/events/${evt.id}/details`}
             className="text-du-purple-500 dark:text-du-lightPurple underline underline-offset-4 font-medium decoration-2 truncate"
@@ -64,7 +65,7 @@ function EventsForMonth({ events }) {
               { evt.eventName }
             </span>
           </Link>
-          <span className="text-center text-du-charcoal-gray dark:text-du-gray">
+          <span className="text-sm sm:col-start-3 sm:text-base sm:text-right text-du-charcoal-gray dark:text-du-gray">
             <span className="hidden sm:inline-block">
               {eventTags.map(tag => (
                 <span key={tag} className={styleClasses.tags}>{tag}</span>
@@ -76,7 +77,7 @@ function EventsForMonth({ events }) {
               />
             </span>
           </span>
-          <span className="text-left">
+          <span className="text-left text-sm sm:text-base sm:text-right sm:col-start-4">
             <DateRange 
               start={dateStart}
               end={dateEnd}

--- a/src/components/elements/EventsForMonth.jsx
+++ b/src/components/elements/EventsForMonth.jsx
@@ -23,28 +23,28 @@ function formatEventTags(tags) {
 
 function EventsForMonth({ events }) {
   const sortedEvents = events.sort(sortByDate);
-
+  
   return sortedEvents.map(evt => {
     const eventTags = formatEventTags(evt.tags);
-
+    
     return (
       <div key={`${evt.id}-${evt.eventName}`} className="border border-gray-300 bg-white dark:bg-du-indigo-900 dark:border-du-lightAqua mb-2 px-2 py-2 rounded">
-        <div className="grid grid-cols-2">
+        <div className="grid grid-cols-3 sm:grid-cols-2">
           <span className="text-left">
             <Link
               to={`/events/${evt.id}/details`}
               className="text-du-purple-500 dark:text-du-lightPurple underline underline-offset-4 font-medium decoration-2"
             >
-              { evt.eventName }
+              {moment(evt.startDate).format('MMMM D, YYYY')}
             </Link>
           </span>
-          <span className="text-right text-du-charcoal-gray dark:text-du-gray">
+          <span className="text-center sm:text-right text-du-charcoal-gray dark:text-du-gray">
             {eventTags.map(tag => (
               <span key={tag} className={styleClasses.tags}>{tag}</span>
             ))}
-            <span className="pl-2">
-              {moment(evt.startDate).format('MMMM D, YYYY')}
-            </span>
+          </span>
+          <span className="pl-2">
+            { evt.eventName }
           </span>
         </div>
       </div>

--- a/src/components/elements/EventsForMonth.jsx
+++ b/src/components/elements/EventsForMonth.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import moment from 'moment';
 import { Link } from 'react-router-dom';
 import { sortByDate } from 'utils/dates';
-// import { DateRange } from 'utils/dateRange'
 
 
 const styleClasses = {

--- a/src/components/elements/EventsForMonth.jsx
+++ b/src/components/elements/EventsForMonth.jsx
@@ -18,12 +18,8 @@ const styleClasses = {
 
 function RenderEventType(data) {
   const eventStyles = `inline-block mr-1 pl-2 pr-2 rounded bg-event-tags-${data.data} text-white`
-  const eventTypes = ['training', 'conference', 'meetup', 'hackathon', 'other', 'webinar']
-  const filteredType = eventTypes.filter(i => data.data.includes(i))
 
-  if (data.data === filteredType[0]){
-    return <span className={eventStyles}>{data.data}</span>
-  }
+  return <span className={eventStyles}>{data.data}</span>
 }
 
 function formatEventTags(tags) {

--- a/src/components/elements/EventsForMonth.jsx
+++ b/src/components/elements/EventsForMonth.jsx
@@ -51,7 +51,6 @@ function EventsForMonth({ events }) {
 
     return (
       <div key={`${evt.id}-${evt.eventName}`} className="border border-gray-300 bg-white dark:bg-du-indigo-900 dark:border-du-lightAqua mb-2 px-2 py-2 rounded">
-        {/* <div className="flex place-content-between"> */}
         <div className="grid grid-cols-3 sm:grid-cols-4">
           <Link
             to={`/events/${evt.id}/details`}
@@ -73,7 +72,7 @@ function EventsForMonth({ events }) {
               />
             </span>
           </span>
-          <span className="text-left text-sm sm:text-base sm:text-right sm:col-start-4">
+          <span className="text-left text-sm sm:col-start-4 sm:text-base sm:text-right">
             <DateRange 
               start={dateStart}
               end={dateEnd}

--- a/src/components/elements/EventsForMonth.jsx
+++ b/src/components/elements/EventsForMonth.jsx
@@ -16,6 +16,15 @@ const styleClasses = {
   `
 }
 
+function RenderEventType(data) {
+  // debugger
+  // eslint-disable-next-line no-console
+  console.log(data.data) 
+  if(data.data === 'conference') {
+    return <span className={`inline-block mr-1 pl-2 pr-2 rounded bg-event-tags-${data.data} text-white`}>{data.data}</span>
+  } 
+}
+
 function formatEventTags(tags) {
   if (tags === null || tags === undefined) return [];
 
@@ -45,18 +54,7 @@ function EventsForMonth({ events }) {
 
     return (
       <div key={`${evt.id}-${evt.eventName}`} className="border border-gray-300 bg-white dark:bg-du-indigo-900 dark:border-du-lightAqua mb-2 px-2 py-2 rounded">
-        <div className="grid grid-cols-3 sm:flex sm:flex-row-reverse sm:space-bet sm:place-content-between">
-          <span className="text-left truncate text-sm sm:text-base sm:col-start-2">
-            <DateRange 
-              start={dateStart}
-              end={dateEnd}
-            />
-          </span>
-          <span className="text-center sm:text-right text-du-charcoal-gray dark:text-du-gray">
-            {eventTags.map(tag => (
-              <span key={tag} className={styleClasses.tags}>{tag}</span>
-            ))}
-          </span>
+        <div className="flex place-content-between">
           <Link
             to={`/events/${evt.id}/details`}
             className="text-du-purple-500 dark:text-du-lightPurple underline underline-offset-4 font-medium decoration-2 truncate"
@@ -65,7 +63,24 @@ function EventsForMonth({ events }) {
               { evt.eventName }
             </span>
           </Link>
-
+          <span className="text-center text-du-charcoal-gray dark:text-du-gray">
+            <span className="hidden sm:inline-block">
+              {eventTags.map(tag => (
+                <span key={tag} className={styleClasses.tags}>{tag}</span>
+              ))}
+            </span>
+            <span>
+              <RenderEventType 
+                data={evt.eventType}
+              />
+            </span>
+          </span>
+          <span className="text-left">
+            <DateRange 
+              start={dateStart}
+              end={dateEnd}
+            />
+          </span>
         </div>
       </div>
     )

--- a/src/components/elements/EventsForMonth.jsx
+++ b/src/components/elements/EventsForMonth.jsx
@@ -60,7 +60,7 @@ function EventsForMonth({ events }) {
               { evt.eventName }
             </span>
           </Link>
-          <span className="text-sm sm:col-start-3 sm:text-base sm:text-right text-du-charcoal-gray dark:text-du-gray">
+          <span className="text-sm text-center sm:col-start-3 sm:text-base sm:text-right text-du-charcoal-gray dark:text-du-gray">
             <span className="hidden sm:inline-block">
               {eventTags.map(tag => (
                 <span key={tag} className={styleClasses.tags}>{tag}</span>

--- a/src/components/elements/EventsForMonth.jsx
+++ b/src/components/elements/EventsForMonth.jsx
@@ -51,8 +51,6 @@ function EventsForMonth({ events }) {
               to={`/events/${evt.id}/details`}
               className="text-du-purple-500 dark:text-du-lightPurple underline underline-offset-4 font-medium decoration-2"
             >
-              {/* {moment(evt.startDate).format('MMMM D, YYYY').slice(0, -6)}{' - '}
-              {dateEnd.split(' ').slice(1).join(' ')} */}
               <DateRange 
                 start={dateStart}
                 end={dateEnd}

--- a/src/components/elements/EventsForMonth.jsx
+++ b/src/components/elements/EventsForMonth.jsx
@@ -22,14 +22,14 @@ function formatEventTags(tags) {
   return tags.trim().split(',').filter(tag => tag !== '');
 }
 
-function DateRange(start, end) {
-  const dateStart = start.start.split(' ')[0]
-  const dateEnd = start.end.split(' ')[0]
+function DateRange(event) {
+  const dateStart = event.start.split(' ')[0]
+  const dateEnd = event.end.split(' ')[0]
 
   if(dateStart === dateEnd) {
-    return <p>{start.start.slice(0, -6) + ' - ' + start.end.substring(start.end.indexOf(' ') + 1)}</p>
+    return <p>{event.start.slice(0, -6) + ' - ' + event.end.substring(event.end.indexOf(' ') + 1)}</p>
   }
-  return <p>{start.start + ' - ' + start.end}</p>
+  return <p>{event.start + ' - ' + event.end}</p>
 }
 
 
@@ -45,27 +45,27 @@ function EventsForMonth({ events }) {
 
     return (
       <div key={`${evt.id}-${evt.eventName}`} className="border border-gray-300 bg-white dark:bg-du-indigo-900 dark:border-du-lightAqua mb-2 px-2 py-2 rounded">
-        <div className="grid grid-cols-3 sm:grid-cols-2">
-          <span className="text-left">
-            <Link
-              to={`/events/${evt.id}/details`}
-              className="text-du-purple-500 dark:text-du-lightPurple underline underline-offset-4 font-medium decoration-2"
-            >
-              <DateRange 
-                start={dateStart}
-                end={dateEnd}
-              />
-
-            </Link>
+        <div className="grid grid-cols-3 sm:flex sm:flex-row-reverse sm:space-bet sm:place-content-between">
+          <span className="text-left truncate text-sm sm:text-base sm:col-start-2">
+            <DateRange 
+              start={dateStart}
+              end={dateEnd}
+            />
           </span>
           <span className="text-center sm:text-right text-du-charcoal-gray dark:text-du-gray">
             {eventTags.map(tag => (
               <span key={tag} className={styleClasses.tags}>{tag}</span>
             ))}
           </span>
-          <span className="pl-2">
-            { evt.eventName }
-          </span>
+          <Link
+            to={`/events/${evt.id}/details`}
+            className="text-du-purple-500 dark:text-du-lightPurple underline underline-offset-4 font-medium decoration-2 truncate"
+          >
+            <span className="pl-2">
+              { evt.eventName }
+            </span>
+          </Link>
+
         </div>
       </div>
     )

--- a/src/components/elements/EventsForMonth.jsx
+++ b/src/components/elements/EventsForMonth.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import moment from 'moment';
 import { Link } from 'react-router-dom';
 import { sortByDate } from 'utils/dates';
+import { DateRange } from 'utils/dateRange'
 
 
 const styleClasses = {
@@ -27,17 +28,6 @@ function formatEventTags(tags) {
 
   return tags.trim().split(',').filter(tag => tag !== '');
 }
-
-function DateRange(event) {
-  const dateStart = event.start.split(' ')[0]
-  const dateEnd = event.end.split(' ')[0]
-
-  if(dateStart === dateEnd) {
-    return <p className="truncate">{event.start.slice(0, -6) + ' - ' + event.end.substring(event.end.indexOf(' ') + 1)}</p>
-  }
-  return <p className="truncate">{event.start + ' - ' + event.end}</p>
-}
-
 
 function EventsForMonth({ events }) {
   const sortedEvents = events.sort(sortByDate);

--- a/src/components/elements/EventsForMonth.jsx
+++ b/src/components/elements/EventsForMonth.jsx
@@ -23,19 +23,18 @@ function formatEventTags(tags) {
 }
 
 function DateRange(start, end) {
-  let dateStart = start.start.split(' ')[0]
-  let dateEnd = start.end.split(' ')[0]
+  const dateStart = start.start.split(' ')[0]
+  const dateEnd = start.end.split(' ')[0]
+
   if(dateStart === dateEnd) {
-    return <p>{start.start.slice(0, -6) + ' - ' + start.end.slice(' ')}</p>
+    return <p>{start.start.slice(0, -6) + ' - ' + start.end.substring(start.end.indexOf(' ') + 1)}</p>
   }
   return <p>{start.start + ' - ' + start.end}</p>
 }
-// description.split(' ').slice(100).join(' ')
 
 
 function EventsForMonth({ events }) {
   const sortedEvents = events.sort(sortByDate);
-
 
   
   return sortedEvents.map(evt => {
@@ -43,9 +42,6 @@ function EventsForMonth({ events }) {
 
     const dateStart = moment(evt.startDate).format('MMMM D, YYYY')
     const dateEnd = moment(evt.endDate).format('MMMM D, YYYY')
-    // const splitDateStart = dateStart.split(' ')[0]
-    // const splitDateEnd = dateEnd.split(' ')[0]
-
 
     return (
       <div key={`${evt.id}-${evt.eventName}`} className="border border-gray-300 bg-white dark:bg-du-indigo-900 dark:border-du-lightAqua mb-2 px-2 py-2 rounded">

--- a/src/components/elements/EventsForMonth.jsx
+++ b/src/components/elements/EventsForMonth.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import moment from 'moment';
 import { Link } from 'react-router-dom';
 import { sortByDate } from 'utils/dates';
-import { DateRange } from 'utils/dateRange'
+// import { DateRange } from 'utils/dateRange'
 
 
 const styleClasses = {
@@ -15,6 +15,16 @@ const styleClasses = {
     rounded
     text-white
   `
+}
+
+function DateRange(event) {
+  const dateStart = event.start.split(' ')[0]
+  const dateEnd = event.end.split(' ')[0]
+
+  if(dateStart === dateEnd) {
+    return <p className="truncate">{event.start.slice(0, -6) + ' - ' + event.end.substring(event.end.indexOf(' ') + 1)}</p>
+  }
+  return <p className="truncate">{event.start + ' - ' + event.end}</p>
 }
 
 function RenderEventType(data) {

--- a/src/components/elements/EventsForMonth.jsx
+++ b/src/components/elements/EventsForMonth.jsx
@@ -3,6 +3,7 @@ import moment from 'moment';
 import { Link } from 'react-router-dom';
 import { sortByDate } from 'utils/dates';
 
+
 const styleClasses = {
   tags: `
     bg-purple-500
@@ -21,12 +22,31 @@ function formatEventTags(tags) {
   return tags.trim().split(',').filter(tag => tag !== '');
 }
 
+function DateRange(start, end) {
+  let dateStart = start.start.split(' ')[0]
+  let dateEnd = start.end.split(' ')[0]
+  if(dateStart === dateEnd) {
+    return <p>{start.start.slice(0, -6) + ' - ' + start.end.slice(' ')}</p>
+  }
+  return <p>{start.start + ' - ' + start.end}</p>
+}
+// description.split(' ').slice(100).join(' ')
+
+
 function EventsForMonth({ events }) {
   const sortedEvents = events.sort(sortByDate);
+
+
   
   return sortedEvents.map(evt => {
     const eventTags = formatEventTags(evt.tags);
-    
+
+    const dateStart = moment(evt.startDate).format('MMMM D, YYYY')
+    const dateEnd = moment(evt.endDate).format('MMMM D, YYYY')
+    // const splitDateStart = dateStart.split(' ')[0]
+    // const splitDateEnd = dateEnd.split(' ')[0]
+
+
     return (
       <div key={`${evt.id}-${evt.eventName}`} className="border border-gray-300 bg-white dark:bg-du-indigo-900 dark:border-du-lightAqua mb-2 px-2 py-2 rounded">
         <div className="grid grid-cols-3 sm:grid-cols-2">
@@ -35,7 +55,13 @@ function EventsForMonth({ events }) {
               to={`/events/${evt.id}/details`}
               className="text-du-purple-500 dark:text-du-lightPurple underline underline-offset-4 font-medium decoration-2"
             >
-              {moment(evt.startDate).format('MMMM D, YYYY')}
+              {/* {moment(evt.startDate).format('MMMM D, YYYY').slice(0, -6)}{' - '}
+              {dateEnd.split(' ').slice(1).join(' ')} */}
+              <DateRange 
+                start={dateStart}
+                end={dateEnd}
+              />
+
             </Link>
           </span>
           <span className="text-center sm:text-right text-du-charcoal-gray dark:text-du-gray">

--- a/src/components/elements/EventsForMonth.jsx
+++ b/src/components/elements/EventsForMonth.jsx
@@ -17,12 +17,13 @@ const styleClasses = {
 }
 
 function RenderEventType(data) {
-  // debugger
-  // eslint-disable-next-line no-console
-  console.log(data.data) 
-  if(data.data === 'conference') {
-    return <span className={`inline-block mr-1 pl-2 pr-2 rounded bg-event-tags-${data.data} text-white`}>{data.data}</span>
-  } 
+  const eventStyles = `inline-block mr-1 pl-2 pr-2 rounded bg-event-tags-${data.data} text-white`
+  const eventTypes = ['training', 'conference', 'meetup', 'hackathon', 'other', 'webinar']
+  const filteredType = eventTypes.filter(i => data.data.includes(i))
+
+  if (data.data === filteredType[0]){
+    return <span className={eventStyles}>{data.data}</span>
+  }
 }
 
 function formatEventTags(tags) {

--- a/src/components/elements/SearchEventCard.jsx
+++ b/src/components/elements/SearchEventCard.jsx
@@ -77,7 +77,7 @@ function SearchEventCard({ eventData }) {
         </div>
 
         <div>
-          <p className="mt-6 font-bold text-base md:text-xl dark:text-du-gray">
+          <p className="mt-6 font-bold text-base md:text-xl dark:text-du-gray truncate">
             {eventData.eventName}
           </p>
         </div>

--- a/src/components/elements/SearchResultViewSelector.js
+++ b/src/components/elements/SearchResultViewSelector.js
@@ -2,8 +2,8 @@ import React from 'react';
 
 const styleClasses = {
   option: 'mr-2 p-2 rounded cursor-pointer',
-  selected: 'dark:bg-du-purple-800 bg-du-purple-500 text-white',
-  unselected: 'dark:bg-du-purple-300 bg-du-purple-200 dark:text-du-purple-100',
+  selected: 'bg-du-purple-500 dark:bg-du-purple-800 text-white',
+  unselected: 'bg-du-purple-200 dark:bg-du-purple-300 dark:text-du-purple-100',
 }
 
 function viewTypeClassName(viewType, selectedView) {

--- a/src/components/elements/SearchResultViewSelector.js
+++ b/src/components/elements/SearchResultViewSelector.js
@@ -1,9 +1,9 @@
 import React from 'react';
 
 const styleClasses = {
-  option: 'mr-2 p-2 rounded',
-  selected: 'bg-du-purple-500 text-white',
-  unselected: 'dark:text-du-purple-100 bg-du-purple-200',
+  option: 'mr-2 p-2 rounded cursor-pointer',
+  selected: 'dark:bg-du-purple-800 bg-du-purple-500 text-white',
+  unselected: 'dark:bg-du-purple-300 bg-du-purple-200 dark:text-du-purple-100',
 }
 
 function viewTypeClassName(viewType, selectedView) {
@@ -24,8 +24,8 @@ function SearchResultViewSelector({ onChange, selectedView }) {
   ]
 
   return (
-    <div className="md:float-right">
-      <label className="mr-2 dark:text-slate-50">View as:</label>
+    <div className="hidden sm:inline-block md:float-right">
+      <label className="mr-2 dark:text-du-gray">View as:</label>
       { viewTypes.map(viewType => (
         <span
           id={viewType.id}

--- a/src/utils/dateRange.js
+++ b/src/utils/dateRange.js
@@ -1,0 +1,12 @@
+
+export function DateRange(event) {
+  const dateStart = event.start.split(' ')[0]
+  const dateEnd = event.end.split(' ')[0]
+
+  if(dateStart === dateEnd) {
+    // eslint-disable-next-line react/react-in-jsx-scope
+    return <p className="truncate">{event.start.slice(0, -6) + ' - ' + event.end.substring(event.end.indexOf(' ') + 1)}</p>
+  }
+  // eslint-disable-next-line react/react-in-jsx-scope
+  return <p className="truncate">{event.start + ' - ' + event.end}</p>
+}

--- a/src/utils/dateRange.js
+++ b/src/utils/dateRange.js
@@ -1,3 +1,0 @@
-export function DateRange(event) {
-  event.start.slice(0, -6) + ' - ' + event.end.substring(event.end.indexOf(' ') + 1)
-}

--- a/src/utils/dateRange.js
+++ b/src/utils/dateRange.js
@@ -1,12 +1,3 @@
-
 export function DateRange(event) {
-  const dateStart = event.start.split(' ')[0]
-  const dateEnd = event.end.split(' ')[0]
-
-  if(dateStart === dateEnd) {
-    // eslint-disable-next-line react/react-in-jsx-scope
-    return <p className="truncate">{event.start.slice(0, -6) + ' - ' + event.end.substring(event.end.indexOf(' ') + 1)}</p>
-  }
-  // eslint-disable-next-line react/react-in-jsx-scope
-  return <p className="truncate">{event.start + ' - ' + event.end}</p>
+  event.start.slice(0, -6) + ' - ' + event.end.substring(event.end.indexOf(' ') + 1)
 }

--- a/src/utils/dates.js
+++ b/src/utils/dates.js
@@ -9,3 +9,8 @@ export function formatEventDetail(date) {
 export function sortByDate(a, b) {
   return moment(a.startDate).isBefore(moment(b.startDate)) ? -1 : 1;
 }
+
+export function formatDateRangeFromEvent(event) {
+  if(!event.start || !event.end) return ''
+  return event.start.slice(0, -6) + ' - ' + event.end.substring(event.end.indexOf(' ') + 1)
+}

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -21,6 +21,7 @@ export function formatEventsForCalendar(events) {
       start: evt.startDate,
       end: evt.endDate,
       title: evt.eventName,
+      type: evt.eventType,
     };
   });
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,9 +15,11 @@ module.exports = {
         'du-purple': {
           100:'#5C456E',
           200: '#E7E1F6',
+          300: '#EEEAF8',
           500: '#6B26FF',
           600: '#783D86',
           700: '#6216F8',
+          800: '#9747FF'
         },
         'du-gray': '#F7FAFC',
         'du-indigo': {


### PR DESCRIPTION
## Ticket Description
fixes #143
Acceptance criteria:
We're focusing on style issues, no features will be added in this ticket. The pagination and limiting of search results, map views, etc will be implemented in a separate ticket.

[Figma Link](https://www.figma.com/file/rs7dsdmKlxdfuQ0wobp5B2/Data-Umbrella?node-id=1457%3A6573)
[Figma Link](https://www.figma.com/file/rs7dsdmKlxdfuQ0wobp5B2/Data-Umbrella?node-id=1457%3A4452)

- [x] Color change to #E7E1F6 on view option buttons
- [x] Color change to #6B26FF on view buttons when selected

- [x] Change mouse over over view buttons to pointer instead of i-beam
- [x] Make "Search Results" and view option buttons visible across view options
- [x] Color change for list view buttons on dark mode to #EEEAF8
- [x] Color change for selected list view button on dark mode to #9747FF
- [x] Color change for text to #F7FAFC in dark mode
- [x] Color change event borders (#00FFFF) appropriately for dark mode
- [x] Dark mode background needs to cover pages and change dark mode color to #151A35 (fixed by ticket PR #235)
- [x] Remove view options for mobile
- [x] Color code event types for calendar, list view, mobile

- [x] Change mobile search results date format to month, date range, year
- [x] Change mobile search results list view order to date then color-coded clickable event title
- [x] Truncated text on event card view


## Description of Changes

- There were so many color changes I didn't take screen shots because they were so small, and so this PR wouldn't get flooded with images. I also couldn't take a photo of the pointer change (it disappears when taking a screenshot) but you can see where I changed it in the files.
- A couple of these items were already changed in other PRs (it's noted) so if you don't see the change that's why.
- The mobile list view order has been changed to reflect the desktop view instead of flipping the fields around (I cleared it with Ilia.)


## Before and After for UI Updates:
Before:
<img width="418" alt="Screenshot 2022-11-08 at 10 11 16 AM" src="https://user-images.githubusercontent.com/59852686/201121007-7185ff25-955d-46d9-8e16-9ac0471f10df.png">
![Screenshot 2022-11-10 at 8 27 47 AM](https://user-images.githubusercontent.com/59852686/201121011-7d7efdc0-c3a1-41d5-ab38-740f1b40f9c6.png)
<img width="614" alt="Screenshot 2022-11-08 at 9 25 29 AM" src="https://user-images.githubusercontent.com/59852686/201121013-5d7ebfe1-209d-41ac-b10a-ac4d4cc39d16.png">
![Screenshot 2022-11-10 at 8 46 36 AM](https://user-images.githubusercontent.com/59852686/201123007-95256f98-a053-4a0d-be1b-f0f1213805a1.png)

After:
<img width="530" alt="Screenshot 2022-11-08 at 9 25 13 AM" src="https://user-images.githubusercontent.com/59852686/201121094-a98a4c12-f44c-4507-80b0-cbda280aa3fe.png">
![Screenshot 2022-11-10 at 8 25 12 AM](https://user-images.githubusercontent.com/59852686/201121098-1d25e066-e06e-4624-8134-6002ff4d0829.png)
![Screenshot 2022-11-10 at 8 31 58 AM](https://user-images.githubusercontent.com/59852686/201121102-768b3cf6-fffc-4894-b8c4-3024f9344002.png)
![Screenshot 2022-11-10 at 8 47 50 AM](https://user-images.githubusercontent.com/59852686/201123023-98700228-dcdd-4f9a-8b85-7d63c551f937.png)


## For PR Reviewer
- [ ] Does this file change the yarn.lock, package.json or package-lock.json file? If so, why?
- [ ] If this pr contains mobile and desktop changes, did you test on IphoneXr and desktop views?
- [ ] Does this file match the related tickets linked figma file, or does it pass the visual smell test?
- [ ] If this file contains javascript, does the javascript pass the smell test?
- [ ] If you don't feel super confident in your review, did you assign someone more senior to double check?

