### PR TITLE
Issue 230: Event Submission Errors

### DIFF
--- a/src/__tests__/elements/EventForm.test.jsx
+++ b/src/__tests__/elements/EventForm.test.jsx
@@ -18,7 +18,7 @@ describe('Event Form', () => {
       fireEvent.click(screen.getByText('Review'))
     });
 
-    expect(screen.getByText(/Field is required/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Field is required/i)[0]).toBeInTheDocument();
   });
 
   it('submits valid event', async () => {
@@ -31,10 +31,12 @@ describe('Event Form', () => {
     );
 
     const eventNameInput = screen.getByLabelText(/Event Name/i);
+    const eventDescriptionInput = screen.getByLabelText(/Event Description/i);
     expect(eventNameInput).toBeInTheDocument();
 
     await act(() => {
       fireEvent.change(eventNameInput, { target: { value: 'Example name' } });
+      fireEvent.change(eventDescriptionInput, { target: { value: 'Example description' } });
       fireEvent.click(screen.getByText('Review'));
     });
 
@@ -43,5 +45,6 @@ describe('Event Form', () => {
     const formSubmitArgs = mockHandleFormSubmit.mock.calls[0][0];
 
     expect(formSubmitArgs['eventName']).toBe('Example name');
+    expect(formSubmitArgs['description']).toBe('Example description');
   });
 });

--- a/src/components/elements/DiscountField.jsx
+++ b/src/components/elements/DiscountField.jsx
@@ -21,7 +21,7 @@ function DiscountField () {
           })}
         </Field>
       </div>
-      <div className="md:col-span-2 md:ml-4">
+      <div className="md:col-span-2 md:mx-4">
         <label>Amount</label>
         <Field
           name="discountValue"

--- a/src/components/elements/EventForm.jsx
+++ b/src/components/elements/EventForm.jsx
@@ -82,7 +82,7 @@ function PostEventFormComponent(props) {
               <Field
                 autoComplete="new-password"
                 className={formStyleClasses.input}
-                component={ValidatedInput}
+                component={ValidatedInput} 
                 label="Event Name"
                 name="eventName"
                 type="text"

--- a/src/components/elements/EventForm.jsx
+++ b/src/components/elements/EventForm.jsx
@@ -51,7 +51,7 @@ function PostEventFormComponent(props) {
           Organization Details
         </h2>
         <section 
-          className={formStyleClasses.organizatioDetail}>
+          className={formStyleClasses.organizationDetail}>
           <Field
             autoComplete="new-password"
             className={formStyleClasses.input}

--- a/src/components/elements/EventForm.jsx
+++ b/src/components/elements/EventForm.jsx
@@ -45,7 +45,7 @@ function PostEventFormComponent(props) {
       <section>
         <h2 className="pb-4 text-xl font-bold md:text-2xl">Organization Details</h2>
         <section
-          className="grid grid-cols-1 rounded border border-slate-300 bg-white p-6 marker:mb-6 dark:bg-transparent md:grid-cols-2 md:grid-rows-1 md:gap-6"
+          className="grid grid-cols-1 rounded border border-slate-300 bg-white p-6 marker:mb-6 dark:border-teal-400 dark:bg-transparent md:grid-cols-2 md:grid-rows-1 md:gap-6"
         >
           <Field  
             autoComplete="new-password"
@@ -74,7 +74,7 @@ function PostEventFormComponent(props) {
       {/* Event Details Section */}
       <section>
         <h2 className="pb-4 text-xl font-bold md:text-2xl">Event Details</h2>
-        <section className="rounded border border-slate-300 bg-white p-6 dark:bg-transparent">
+        <section className="rounded border border-slate-300 bg-white p-6 dark:bg-transparent dark:border-teal-400">
           <section className="flex flex-col">
             <div className="max-w-sm pb-4">
               <Field
@@ -219,7 +219,7 @@ function PostEventFormComponent(props) {
       {/* Notes section */}
       <section>
         <h2 className="pb-4 text-xl font-bold md:text-2xl">Notes</h2>
-        <div className="grid grid-cols-1 gap-6 rounded border border-zinc-300 bg-white p-4 dark:bg-transparent md:grid-cols-2">
+        <div className="grid grid-cols-1 gap-6 rounded border border-zinc-300 bg-white p-4 dark:bg-transparent dark:border-teal-400 md:grid-cols-2">
           <div>
             <TextField
               component="textarea"
@@ -245,7 +245,7 @@ function PostEventFormComponent(props) {
       {/* Other section */}
       <section>
         <h2 className="pb-4 text-xl font-bold md:text-2xl">Other</h2>
-        <section className="grid gap-6 rounded border border-zinc-300 bg-white p-4 dark:bg-transparent md:grid-cols-2">
+        <section className="grid gap-6 rounded border border-zinc-300 bg-white p-4 dark:bg-transparent dark:border-teal-400 md:grid-cols-2">
           <div>
             <div className="mb-6">
               <label htmlFor="codeOfConductUrl">
@@ -277,7 +277,7 @@ function PostEventFormComponent(props) {
       {/* Accessibility Options section */}
       <section>
         <h2 className="pb-4 text-xl font-bold md:text-2xl">Accessibility</h2>
-        <section className="grid gap-6 rounded border border-zinc-300 bg-white p-4 dark:bg-transparent">
+        <section className="grid gap-6 rounded border border-zinc-300 bg-white p-4 dark:bg-transparent dark:border-teal-400">
           <AccessibilityDetailField
             value={values.accessibilityOptions}
             onChange={setFieldValue}
@@ -288,7 +288,7 @@ function PostEventFormComponent(props) {
       {/* Featured Event section */}
       <section>
         <h2 className="pb-4 text-xl font-bold md:text-2xl">Featured Event</h2>
-        <section className="grid gap-6 rounded border border-zinc-300 bg-white p-4 dark:bg-transparent">
+        <section className="grid gap-6 rounded border border-zinc-300 bg-white p-4 dark:bg-transparent dark:border-teal-400">
           <FeaturedEventField
             value={values.featured}
             onChange={setFieldValue}
@@ -298,7 +298,7 @@ function PostEventFormComponent(props) {
 
       <section className="mb-6 grid gap-1 md:grid-rows-1 md:justify-end">
         <div className="grid grid-cols-1 md:block">
-          <button className="p-2 underline dark:text-white">Clear Form</button>
+          <button className="p-2 mr-2 underline dark:text-white">Clear Form</button>
           <button className={formStyleClasses.reviewButton} type="submit">
             Review
           </button>

--- a/src/components/elements/EventForm.jsx
+++ b/src/components/elements/EventForm.jsx
@@ -12,6 +12,7 @@ import formStyleClasses from 'styles/forms';
 // Components
 import DatePickerField from 'components/elements/DatePickerField';
 import ValidatedInput from 'components/elements/ValidatedInput';
+import ValidatedTextArea from './ValidatedTextArea';
 import EventTypeField from 'components/elements/EventTypeField';
 import DiscountField from 'components/elements/DiscountField';
 import AccessibilityDetailField from 'components/elements/AccessibilityDetailField';
@@ -83,18 +84,20 @@ function PostEventFormComponent(props) {
                 autoComplete="new-password"
                 className={formStyleClasses.input}
                 component={ValidatedInput} 
-                label="Event Name"
+                label="Event Name*"
                 name="eventName"
                 type="text"
                 id="eventName"
               />
             </div>
             <div>
-              <label htmlFor="description">Event Description*</label>
+
               <Field
-                component="textarea"
+                component={ValidatedTextArea}
+                type="textarea"
                 id="description"
                 name="description"
+                label="Event Description*"
                 className={formStyleClasses.textarea}
               />
             </div>
@@ -185,7 +188,6 @@ function PostEventFormComponent(props) {
                 </div>
               </section>
               <section
-                className="grid grid-cols-2 gap-6"
                 role="group"
                 aria-labelledby="virtual-option-radio-group"
               >
@@ -448,6 +450,7 @@ export function handleSubmit(values, { props }) {
  */
 export const validationSchema = Yup.object().shape({
   eventName: Yup.string().required('Field is required'),
+  description: Yup.string().required('Field is required'),
 });
 
 /**

--- a/src/components/elements/EventForm.jsx
+++ b/src/components/elements/EventForm.jsx
@@ -237,6 +237,24 @@ function PostEventFormComponent(props) {
                     autoComplete="new-password"
                   />
                 </div>
+                <div className="mb-6">
+                  <label>Tags</label>
+                  <Field
+                    name="Tags"
+                    type="text"
+                    className={formStyleClasses.input}
+                    autoComplete="new-password"
+                  />
+                </div>
+                <div className="mb-6">
+                  <label>Event Hashtag(s)</label>
+                  <Field
+                    name="event-hashtags"
+                    type="text"
+                    className={formStyleClasses.input}
+                    autoComplete="new-password"
+                  />
+                </div>
               </div>
             </section>
           </section>

--- a/src/components/elements/EventForm.jsx
+++ b/src/components/elements/EventForm.jsx
@@ -36,18 +36,21 @@ function PostEventFormComponent(props) {
   return (
     <Form className="container mx-auto grid gap-6 p-0 md:mb-10 md:px-10 md:pb-10">
       <section className="pt-6">
-        <h1 className="text-2xl font-bold md:text-4xl">Event Submission Form</h1>
+        <h1 className="text-2xl font-bold md:text-4xl">
+          Event Submission Form
+        </h1>
         <p className="text-md py-2 pl-0.5 md:text-lg">
-          Events can be submitted by anybody but will need to be approved by admins.
+          Events can be submitted by anybody but will need to be approved by
+          admins.
         </p>
       </section>
       {/* Organization details section */}
       <section>
-        <h2 className="pb-4 text-xl font-bold md:text-2xl">Organization Details</h2>
-        <section
-          className="grid grid-cols-1 rounded border border-slate-300 bg-white p-6 marker:mb-6 dark:border-teal-400 dark:bg-transparent md:grid-cols-2 md:grid-rows-1 md:gap-6"
-        >
-          <Field  
+        <h2 className="pb-4 text-xl font-bold md:text-2xl">
+          Organization Details
+        </h2>
+        <section className="grid grid-cols-1 rounded border border-slate-300 bg-white p-6 marker:mb-6 dark:border-teal-400 dark:bg-transparent md:grid-cols-2 md:grid-rows-1 md:gap-6">
+          <Field
             autoComplete="new-password"
             className={formStyleClasses.input}
             component={ValidatedInput}
@@ -57,9 +60,7 @@ function PostEventFormComponent(props) {
             id="organizationName"
           />
           <section className="mt-4 md:mt-0">
-            <label htmlFor="organizationUrl">
-              Organization URL
-            </label>
+            <label htmlFor="organizationUrl">Organization URL</label>
             <Field
               autoComplete="new-password"
               id="organizationUrl"
@@ -112,22 +113,38 @@ function PostEventFormComponent(props) {
                   className={formStyleClasses.input}
                 />
               </section>
-              
+
               <section className="grid grid-cols-2 gap-2">
                 <div className="col-span-1">
-                  <TimeSlotField id="startTime" name="startTime" label="Start Time*" />
+                  <TimeSlotField
+                    id="startTime"
+                    name="startTime"
+                    label="Start Time*"
+                  />
                 </div>
 
                 <div className="col-span-1">
-                  <TimeSlotField id="endTime" name="endTime" label="End Time*" />
+                  <TimeSlotField
+                    id="endTime"
+                    name="endTime"
+                    label="End Time*"
+                  />
                 </div>
               </section>
               <section>
                 <label>Time Zone*</label>
-                <Field name="timezone" component="select" className={formStyleClasses.select}>
+                <Field
+                  name="timezone"
+                  component="select"
+                  className={formStyleClasses.select}
+                >
                   <option value={null}>Select a time zone</option>
                   {timezones.map(({ name, text }) => {
-                    return <option key={text} value={text}>{name}</option>
+                    return (
+                      <option key={text} value={text}>
+                        {name}
+                      </option>
+                    );
                   })}
                 </Field>
               </section>
@@ -151,44 +168,53 @@ function PostEventFormComponent(props) {
               <section className="grid grid-cols-2 gap-6">
                 <div>
                   <label>Registration Start Date</label>
-                  <DatePickerField name="registrationStartDate" className={formStyleClasses.input} />
+                  <DatePickerField
+                    name="registrationStartDate"
+                    className={formStyleClasses.input}
+                  />
                 </div>
               </section>
               <section className="grid grid-cols-2 gap-6">
                 <div>
                   <label>Registration Start Date</label>
-                  <DatePickerField name="registrationStartDate" className={formStyleClasses.input} />
+                  <DatePickerField
+                    name="registrationStartDate"
+                    className={formStyleClasses.input}
+                  />
                 </div>
               </section>
-
-              <section className="grid grid-cols-2 gap-6" role="group" aria-labelledby="virtual-option-radio-group" >
+              <section
+                className="grid grid-cols-2 gap-6"
+                role="group"
+                aria-labelledby="virtual-option-radio-group"
+              >
                 <div>
                   <label className="mr-6">
                     <Field
-                    name="in-person"
-                    type="radio"
-                    value="in-person"
-                    className={formStyleClasses.radioButtonValues}
-                      />
-                      In-person
+                      name="in-person"
+                      type="radio"
+                      value="in-person"
+                      className={formStyleClasses.radioButtonValues}
+                    />
+                    In-person
                   </label>
                   <label className="mr-6">
                     <Field
-                    name="in-person"
-                    type="radio"
-                    value="virutal"
-                    className={formStyleClasses.radioButtonValues}
-                      />
-                      Virtual
+                      name="in-person"
+                      type="radio"
+                      value="virutal"
+                      className={formStyleClasses.radioButtonValues}
+                    />
+                    Virtual
                   </label>
                   <label className="mr-6">
                     <Field
-                    name="in-person"
-                    type="radio"
-                    value="both"
-                    className={formStyleClasses.radioButtonValues}
-                      />
-                      Both
+                      name="in-person"
+                      type="radio"
+                      value="both"
+                      className={formStyleClasses.radioButtonValues}
+                    />
+                    Both
                   </label>
                 </div>
               </section>
@@ -197,8 +223,8 @@ function PostEventFormComponent(props) {
               <div
                 className="border-1 col-span-2 grid place-content-center rounded border border-black pt-2 text-center dark:border-teal-400 md:col-span-1"
                 style={{
-                  minHeight: '6rem',
-                  minWidth: '6rem'
+                  minHeight: "6rem",
+                  minWidth: "6rem",
                 }}
               >
                 <ImagePreview url={values.imageFile} />
@@ -207,7 +233,7 @@ function PostEventFormComponent(props) {
               <div className="col-span-2 rounded py-6">
                 <div className="mb-6 h-16">
                   <label>Upload Image</label>
-                  <br/>
+                  <br />
                   <input
                     style={{ maxWidth: "80%" }}
                     type="file"
@@ -237,14 +263,43 @@ function PostEventFormComponent(props) {
                     autoComplete="new-password"
                   />
                 </div>
-                <div className="mb-6">
-                  <label>Tags</label>
-                  <Field
-                    name="Tags"
-                    type="text"
-                    className={formStyleClasses.input}
-                    autoComplete="new-password"
-                  />
+
+                <div className="container mx-auto mb-4">
+                <label>Tags</label>
+                  <div className="relative text-gray-600 focus-within:text-gray-400">
+                    <span className="absolute inset-y-0 left-0 flex items-center pl-2">
+                      <button
+                        type="submit"
+                        className={`
+                          p-1
+                          focus:outline-none
+                          focus:shadow-outline
+                          text-du-purple-500
+                          font-bold
+                        `}
+                            >
+                        <svg
+                          fill="none"
+                          stroke="currentColor"
+                          strokeLinecap="round"
+                          strokeLinejoin="round"
+                          strokeWidth="3"
+                          viewBox="0 0 24 24"
+                          className="w-6 h-6"
+                          >
+                          <path d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
+                        </svg>
+                      </button>
+                    </span>
+
+                    <Field
+                      type="search"
+                      name="search"
+                      className={`${formStyleClasses.searchInput} pl-10 focus:outline-none`}
+                      placeholder="Search"
+                      autoComplete="off"
+                    />
+                  </div>
                 </div>
                 <div className="mb-6">
                   <label>Event Hashtag(s)</label>
@@ -252,6 +307,7 @@ function PostEventFormComponent(props) {
                     name="event-hashtags"
                     type="text"
                     className={formStyleClasses.input}
+                    placeholder="#PyCon2022"
                     autoComplete="new-password"
                   />
                 </div>
@@ -298,9 +354,7 @@ function PostEventFormComponent(props) {
         <section className="grid gap-6 rounded border border-zinc-300 bg-white p-4 dark:bg-transparent dark:border-teal-400 md:grid-cols-2">
           <div>
             <div className="mb-6">
-              <label htmlFor="codeOfConductUrl">
-                Code Of Conduct URL
-              </label>
+              <label htmlFor="codeOfConductUrl">Code Of Conduct URL</label>
               <Field
                 autoComplete="new-password"
                 id="codeOfConductUrl"
@@ -348,14 +402,16 @@ function PostEventFormComponent(props) {
 
       <section className="mb-6 grid gap-1 md:grid-rows-1 md:justify-end">
         <div className="grid grid-cols-1 md:block">
-          <button className="p-2 mr-2 underline dark:text-white">Clear Form</button>
+          <button className="p-2 mr-2 underline dark:text-white">
+            Clear Form
+          </button>
           <button className={formStyleClasses.reviewButton} type="submit">
             Review
           </button>
         </div>
       </section>
     </Form>
-  )
+  );
 }
 
 /**

--- a/src/components/elements/EventForm.jsx
+++ b/src/components/elements/EventForm.jsx
@@ -51,7 +51,7 @@ function PostEventFormComponent(props) {
           Organization Details
         </h2>
         <section 
-          className={formStyleClasses.oragnizationDetails}>
+          className={formStyleClasses.oragnization}>
           <Field
             autoComplete="new-password"
             className={formStyleClasses.input}

--- a/src/components/elements/EventForm.jsx
+++ b/src/components/elements/EventForm.jsx
@@ -156,8 +156,40 @@ function PostEventFormComponent(props) {
               </section>
               <section className="grid grid-cols-2 gap-6">
                 <div>
-                  <label>Registration End Date</label>
-                  <DatePickerField name="registrationEndDate" className={formStyleClasses.input} />
+                  <label>Registration Start Date</label>
+                  <DatePickerField name="registrationStartDate" className={formStyleClasses.input} />
+                </div>
+              </section>
+
+              <section className="grid grid-cols-2 gap-6" role="group" aria-labelledby="virtual-option-radio-group" >
+                <div>
+                  <label className="mr-6">
+                    <Field
+                    name="in-person"
+                    type="radio"
+                    value="in-person"
+                    className={formStyleClasses.radioButtonValues}
+                      />
+                      In-person
+                  </label>
+                  <label className="mr-6">
+                    <Field
+                    name="in-person"
+                    type="radio"
+                    value="virutal"
+                    className={formStyleClasses.radioButtonValues}
+                      />
+                      Virtual
+                  </label>
+                  <label className="mr-6">
+                    <Field
+                    name="in-person"
+                    type="radio"
+                    value="both"
+                    className={formStyleClasses.radioButtonValues}
+                      />
+                      Both
+                  </label>
                 </div>
               </section>
             </section>

--- a/src/components/elements/EventForm.jsx
+++ b/src/components/elements/EventForm.jsx
@@ -49,7 +49,8 @@ function PostEventFormComponent(props) {
         <h2 className="pb-4 text-xl font-bold md:text-2xl">
           Organization Details
         </h2>
-        <section className="grid grid-cols-1 rounded border border-slate-300 bg-white p-6 marker:mb-6 dark:border-teal-400 dark:bg-transparent md:grid-cols-2 md:grid-rows-1 md:gap-6">
+        <section 
+          className={formStyleClasses.oragnizationDetails}>
           <Field
             autoComplete="new-password"
             className={formStyleClasses.input}
@@ -265,7 +266,7 @@ function PostEventFormComponent(props) {
                 </div>
 
                 <div className="container mx-auto mb-4">
-                <label>Tags</label>
+                  <label>Tags</label>
                   <div className="relative text-gray-600 focus-within:text-gray-400">
                     <span className="absolute inset-y-0 left-0 flex items-center pl-2">
                       <button
@@ -277,7 +278,7 @@ function PostEventFormComponent(props) {
                           text-du-purple-500
                           font-bold
                         `}
-                            >
+                      >
                         <svg
                           fill="none"
                           stroke="currentColor"
@@ -286,7 +287,7 @@ function PostEventFormComponent(props) {
                           strokeWidth="3"
                           viewBox="0 0 24 24"
                           className="w-6 h-6"
-                          >
+                        >
                           <path d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path>
                         </svg>
                       </button>

--- a/src/components/elements/EventForm.jsx
+++ b/src/components/elements/EventForm.jsx
@@ -51,7 +51,7 @@ function PostEventFormComponent(props) {
           Organization Details
         </h2>
         <section 
-          className={formStyleClasses.oragnization}>
+          className={formStyleClasses.organizatioDetail}>
           <Field
             autoComplete="new-password"
             className={formStyleClasses.input}

--- a/src/components/elements/FeaturedEventField.jsx
+++ b/src/components/elements/FeaturedEventField.jsx
@@ -1,4 +1,5 @@
 import { React } from 'react';
+import { eventStyleClasses } from 'styles/events';
 
 function FeaturedEventField({ value, onChange }) {
   const handleChange = () => {
@@ -12,9 +13,15 @@ function FeaturedEventField({ value, onChange }) {
         follow the link to make a donation to this Event Board on Open
         Collective.
       </p>
-      <br></br>
-      <div id="featured-event-donation-info" className="border">
-        <p>$1-99: General Donation $100+: Featured Event</p>
+
+      <div 
+        id="featured-event-donation-info"
+        className={eventStyleClasses.donationPillBox}
+        >
+        <p>
+          $1-99: General Donation
+          <span className="pl-6">$100+: Featured Event</span>
+        </p>
       </div>
       <div>
         <input

--- a/src/components/elements/FeaturedEventField.jsx
+++ b/src/components/elements/FeaturedEventField.jsx
@@ -17,7 +17,7 @@ function FeaturedEventField({ value, onChange }) {
       <div 
         id="featured-event-donation-info"
         className={eventStyleClasses.donationPillBox}
-        >
+      >
         <p>
           $1-99: General Donation
           <span className="pl-6">$100+: Featured Event</span>

--- a/src/components/elements/FeaturedEventField.jsx
+++ b/src/components/elements/FeaturedEventField.jsx
@@ -8,13 +8,16 @@ function FeaturedEventField({ value, onChange }) {
   return (
     <div className="rounded">
       <p>
-        If you would like this event to be featured,
-        check the box below and follow the link to make
-        a donation to this Event Board on Open Collective.
+        If you would like this event to be featured, check the box below and
+        follow the link to make a donation to this Event Board on Open
+        Collective.
       </p>
       <br></br>
+      <div id="featured-event-donation-info" className="border">
+        <p>$1-99: General Donation $100+: Featured Event</p>
+      </div>
       <div>
-        <input 
+        <input
           id="featured-event"
           name="feature-event"
           type="checkbox"
@@ -28,7 +31,7 @@ function FeaturedEventField({ value, onChange }) {
       </div>
       <br></br>
       <div>
-        <a 
+        <a
           target="_blank"
           rel="noreferrer"
           className="font-medium underline"
@@ -38,7 +41,7 @@ function FeaturedEventField({ value, onChange }) {
         </a>
       </div>
     </div>
-  )
+  );
 }
 
 export default FeaturedEventField;

--- a/src/components/elements/ReviewEventActionsSection.jsx
+++ b/src/components/elements/ReviewEventActionsSection.jsx
@@ -5,7 +5,7 @@ function ReviewEventActionsSection({ handleSubmit, editEvent }) {
   return (
     <div className="grid grid-cols-2 w-1/2 float-right gap-1">
       <button
-        className="p-2 underline underline-offset-4 text-xl"
+        className="p-2 underline underline-offset-4 text-xl dark:text-white"
         onClick={editEvent}
       >
         Edit Event

--- a/src/components/elements/SpeakersField.jsx
+++ b/src/components/elements/SpeakersField.jsx
@@ -71,7 +71,7 @@ function SpeakersField ({ value, onChange }) {
     <div>
       <div className="mb-2">
         <h2 className="text-xl md:text-2xl pb-4 inline font-bold">Speakers</h2>
-        <button className="float-right dark:text-white" type="button" onClick={addSpeaker}>
+        <button className="float-right font-bold dark:text-du-lightPurple" type="button" onClick={addSpeaker}>
           Add a Speaker
         </button>
       </div>

--- a/src/components/elements/ValidatedInput.jsx
+++ b/src/components/elements/ValidatedInput.jsx
@@ -13,7 +13,7 @@ function ValidatedInput({
     <div>
       <label htmlFor={props.id}>
         <span className="pr-2 inline-block">{ props.label }</span>
-        { showErrors && <span className="text-red-600">{fieldErrors}</span> }
+        { showErrors && <span className="text-red-600 dark:text-red-600">{fieldErrors}</span> }
       </label>
       <input {...field} {...props} />
     </div>

--- a/src/components/elements/ValidatedInput.jsx
+++ b/src/components/elements/ValidatedInput.jsx
@@ -13,7 +13,7 @@ function ValidatedInput({
     <div>
       <label htmlFor={props.id}>
         <span className="pr-2 inline-block">{ props.label }</span>
-        { showErrors && <span className="text-red-600 dark:text-red-600">{fieldErrors}</span> }
+        { showErrors && <span className="text-[#FB2F2F] dark:text-[#FB2F2F]">{fieldErrors}</span> }
       </label>
       <input {...field} {...props} />
     </div>

--- a/src/components/elements/ValidatedTextArea.jsx
+++ b/src/components/elements/ValidatedTextArea.jsx
@@ -13,7 +13,7 @@ function ValidatedTextArea({
     <div>
       <label htmlFor={props.id}>
         <span className="pr-2">{ props.label }</span>
-        { showErrors && <span className="inline-block text-red-600 dark:text-red-600">{fieldErrors}</span> }
+        { showErrors && <span className="inline-block text-[#FB2F2F] dark:text-[#FB2F2F]">{fieldErrors}</span> }
       </label>
       <textarea {...field} {...props} />
     </div>

--- a/src/components/elements/ValidatedTextArea.jsx
+++ b/src/components/elements/ValidatedTextArea.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+function ValidatedTextArea({
+  field, // { name, value, onChange, onBlur }
+  form: { touched, errors }, // also values, setXXXX, handleXXXX, dirty, isValid, status, etc.
+  ...props
+}) {
+  const fieldTouched = touched[field.name];
+  const fieldErrors = errors[field.name];
+  const showErrors = fieldTouched && fieldErrors;
+
+  return (
+    <div>
+      <label htmlFor={props.id}>
+        <span className="pr-2">{ props.label }</span>
+        { showErrors && <span className="inline-block text-red-600 dark:text-red-600">{fieldErrors}</span> }
+      </label>
+      <textarea {...field} {...props} />
+    </div>
+  )
+}
+
+export default ValidatedTextArea;

--- a/src/styles/events.js
+++ b/src/styles/events.js
@@ -8,7 +8,7 @@ export const eventStyleClasses = {
     md:grid-cols-2
   `,
   imageContainer: "bg-gray-300",
-  eventTypePillbox:`
+  eventTypePillbox: `
     block 
     mb-4 
     bg-pink-300 
@@ -20,7 +20,7 @@ export const eventStyleClasses = {
     text-xl 
     font-medium
   `,
-  infoTextSection:`
+  infoTextSection: `
     bg-white 
     p-6 
     border
@@ -38,7 +38,7 @@ export const eventStyleClasses = {
     text-lg
     font-normal
   `,
-  donationPillBox:`
+  donationPillBox: `
     border 
     border-black
     block 

--- a/src/styles/events.js
+++ b/src/styles/events.js
@@ -7,9 +7,29 @@ export const eventStyleClasses = {
     mb-16
     md:grid-cols-2
   `,
-  imageContainer: 'bg-gray-300',
-  eventTypePillbox: 'block mb-4 bg-pink-300 pl-1 pr-1 w-1/4 text-center rounded text-xl font-medium',
-  infoTextSection: 'bg-white p-6 border-slate-300 border-solid border rounded mb-6',
+  imageContainer: "bg-gray-300",
+  eventTypePillbox:`
+    block 
+    mb-4 
+    bg-pink-300 
+    pl-1 
+    pr-1 
+    w-1/4 
+    text-center 
+    rounded 
+    text-xl 
+    font-medium
+  `,
+  infoTextSection:`
+    bg-white 
+    p-6 
+    border
+    border-slate-300 
+    border-solid  
+    rounded mb-6 
+    dark:bg-transparent 
+    dark:border-du-lightAqua 
+    dark:text-white`,
   submitButton: `
     bg-du-purple-500
     text-white
@@ -17,5 +37,5 @@ export const eventStyleClasses = {
     rounded
     text-lg
     font-normal
-  `
+  `,
 };

--- a/src/styles/events.js
+++ b/src/styles/events.js
@@ -38,4 +38,19 @@ export const eventStyleClasses = {
     text-lg
     font-normal
   `,
+  donationPillBox:`
+    border 
+    border-black
+    block 
+    my-6 
+    bg-du-lightBlue 
+    px-1 
+    py-2 
+    w-2/5 
+    text-center 
+    rounded 
+    text-medium
+    dark:bg-transparent
+    dark:border-du-lightAqua 
+  `,
 };

--- a/src/styles/forms.js
+++ b/src/styles/forms.js
@@ -4,7 +4,7 @@ const formStyleClasses = {
     border
     border-black
     dark:border-teal-400
-    dark:bg-transparent
+    dark:bg-du-deepPurple
     w-full
     rounded-md
     h-14

--- a/src/styles/forms.js
+++ b/src/styles/forms.js
@@ -148,6 +148,13 @@ const formStyleClasses = {
     text-lg
     font-normal
   `,
+  radioButtonValues:`
+    rounded-md
+    mx-2
+    p-2
+    md:row-start-2
+    md:col-span-2
+  `,
 };
 
 export default formStyleClasses;

--- a/src/styles/forms.js
+++ b/src/styles/forms.js
@@ -155,7 +155,7 @@ const formStyleClasses = {
     md:row-start-2
     md:col-span-2
   `,
-  oragnization: `
+  organizationDetail: `
   grid 
   grid-cols-1 
   rounded 

--- a/src/styles/forms.js
+++ b/src/styles/forms.js
@@ -59,6 +59,7 @@ const formStyleClasses = {
     border-black
     dark:border-teal-400
     dark:bg-transparent
+    dark:text-white
     w-full
     h-40
     rounded

--- a/src/styles/forms.js
+++ b/src/styles/forms.js
@@ -155,6 +155,21 @@ const formStyleClasses = {
     md:row-start-2
     md:col-span-2
   `,
+  oragnizationDetails: `
+  grid 
+  grid-cols-1 
+  rounded 
+  border 
+  border-slate-300 
+  bg-white 
+  p-6 
+  marker:mb-6 
+  dark:border-teal-400 
+  dark:bg-transparent 
+  md:grid-cols-2 
+  md:grid-rows-1 
+  md:gap-6
+`,
 };
 
 export default formStyleClasses;

--- a/src/styles/forms.js
+++ b/src/styles/forms.js
@@ -155,7 +155,7 @@ const formStyleClasses = {
     md:row-start-2
     md:col-span-2
   `,
-  oragnizationDetails: `
+  oragnization: `
   grid 
   grid-cols-1 
   rounded 


### PR DESCRIPTION
## Ticket Description
<-- Copy and paste or write the tickets description here-->
Fixes #230 

## Description of Changes
<-- Brief description of the changes you made, files you touched, etc -->
Audit: https://docs.google.com/spreadsheets/d/1mfn1s6-ncwnaIYpDfD0OH1md6Ni2YB38N_qeyBZQwR8/edit#gid=464070281
Figma: https://www.figma.com/file/rs7dsdmKlxdfuQ0wobp5B2/Data-Umbrella?node-id=1457%3A5091

- [x]  Large text box border should be bold (eg: Event description, Events notes, Volunteering notes) and darkmode teal
- [x]  "Add a Speaker" is not purple in dark mode
- [x]  f/u with Ilia/Reshema about the multiple choice other options (in-person, online, both) event hashtags
- [x]  Need more spacing between buttons on the initial Event Form (see below image)
- [x] In dark mode cannot identify quickly the error message as its the same color as text, change to bright red(?) (see below image) <-- check if this is an accessibility issue
- [x] On Review page it has "Back to Results" link, which brings us back to Home. Should either remove or "Back to Post" (see below image) - move this into a new ticket
- [x] On Review page the Edit Event is in Black #000000 and hard to read in Dark mode (see below image)

<img width="249" alt="Screen Shot 2022-11-04 at 10 45 02 AM" src="https://user-images.githubusercontent.com/88496806/200010919-6aba2f9d-057e-4cd3-b774-4935e0dfd183.png">
<img width="478" alt="Screen Shot 2022-11-04 at 10 45 26 AM" src="https://user-images.githubusercontent.com/88496806/200010937-d2fce7b2-de08-49e5-8618-ff2b51b06c3e.png">
<img width="1540" alt="Screen Shot 2022-11-04 at 10 44 40 AM" src="https://user-images.githubusercontent.com/88496806/200010956-f300ae78-d0f8-404e-88c6-aa8c334750df.png">

## Before and After for UI Updates
<-- You should have 2 images minimum, for desktop, 4 for mobile and desktop combined -->

Before:
![Screen Shot 2022-11-08 at 3 38 34 PM](https://user-images.githubusercontent.com/52011611/200700772-6e5be7bf-d1ac-4ca2-9aaa-aa55223a3003.png)
![Screen Shot 2022-11-08 at 3 31 28 PM](https://user-images.githubusercontent.com/52011611/200700815-3e4fc0c2-2691-4720-b15d-2aa74f9d6a03.png)


After:
![Screen Shot 2022-11-08 at 3 31 19 PM](https://user-images.githubusercontent.com/52011611/200700803-3e0de952-338f-4696-8c97-c939df464350.png)
![Screen Shot 2022-11-08 at 3 37 14 PM](https://user-images.githubusercontent.com/52011611/200700804-6f7273fc-ca37-4d42-a5cb-0f9bc4f57d3f.png)

## [78e10bf](https://github.com/data-umbrella/event-board-web/pull/259/commits/78e10bfd711da977a0c7ae906b733a5b04841132)
Before:
<img width="588" alt="Screen Shot 2022-11-09 at 1 13 44 PM" src="https://user-images.githubusercontent.com/52011611/200961705-abf3d84f-9555-4efa-9f8a-89a16140d4ad.png">
![Screen Shot 2022-11-09 at 3 11 22 PM](https://user-images.githubusercontent.com/52011611/200961822-6d0ed65b-4920-4520-a0d4-4b9e5a5629c0.png)

![Screen Shot 2022-11-09 at 10 15 54 AM](https://user-images.githubusercontent.com/52011611/200961840-54050501-3b50-446a-9fc2-acbd982feb80.png)


After:
<img width="489" alt="Screen Shot 2022-11-09 at 1 13 04 PM" src="https://user-images.githubusercontent.com/52011611/200961721-5d51372a-ba95-4512-9600-9e6c71785c48.png">
![Screen Shot 2022-11-09 at 11 33 03 AM](https://user-images.githubusercontent.com/52011611/200961740-db34f0ee-45f2-4812-80cc-058b449231c9.png)
![Screen Shot 2022-11-09 at 10 15 34 AM](https://user-images.githubusercontent.com/52011611/200961855-938590b9-6647-42f4-aa96-57fb8a3cf40a.png)


## For PR Reviewer
- [ ] Does this file change the yarn.lock, package.json or package-lock.json file? If so, why?
- [ ] If this pr contains mobile and desktop changes, did you test on IphoneXr and desktop views?
- [ ] Does this file match the related tickets linked figma file, or does it pass the visual smell test?
- [ ] If this file contains javascript, does the javascript pass the smell test?
- [ ] If you don't feel super confident in your review, did you assign someone more senior to double check?

