### PR TITLE
Issue #93 - fixed image sizing

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -106,9 +106,9 @@ nav li {
 }
 
 .card-img {
-   background-size: cover;
-   background-repeat: no-repeat;
-   background-position: center center;
-   min-height: 12rem;
-   height: 60%;
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center center;
+  min-height: 12rem;
+  height: 60%;
 }


### PR DESCRIPTION
## Ticket Description
fixes #93 


## Description of Changes
- [x] We need to either coerce the image sizes or figure out a clean way to auto adjust the size.

Just changed a css property so images would fit within image container.

## Before and After for UI Updates
Before:
<img width="1426" alt="Screenshot 2022-11-14 at 9 53 28 AM" src="https://user-images.githubusercontent.com/59852686/201705685-9d3bed63-cd52-4090-b10f-db4d0ff4b525.png">

After:
<img width="1407" alt="Screenshot 2022-11-14 at 9 53 43 AM" src="https://user-images.githubusercontent.com/59852686/201705720-6ce0556d-4c7c-44c5-9646-4e715a5cb95c.png">


## For PR Reviewer
- [ ] Does this file change the yarn.lock, package.json or package-lock.json file? If so, why?
- [ ] If this pr contains mobile and desktop changes, did you test on IphoneXr and desktop views?
- [ ] Does this file match the related tickets linked figma file, or does it pass the visual smell test?
- [ ] If this file contains javascript, does the javascript pass the smell test?
- [ ] If you don't feel super confident in your review, did you assign someone more senior to double check?

