### PR TITLE
make Data Umbrella Initiative clickable

### DIFF
--- a/src/components/elements/IntroductionSection.jsx
+++ b/src/components/elements/IntroductionSection.jsx
@@ -1,5 +1,3 @@
-//import { DONATE_URL } from 'constants/urls';
-//import { DATA_UMBRELLA_URL } from 'constants/urls';
 import { DONATE_URL, DATA_UMBRELLA_URL } from 'constants/urls';
 import React from 'react';
 import ExternalLinkIcon from 'assets/ui/externalLink.svg'

--- a/src/components/elements/IntroductionSection.jsx
+++ b/src/components/elements/IntroductionSection.jsx
@@ -1,4 +1,6 @@
-import { DONATE_URL } from 'constants/urls';
+//import { DONATE_URL } from 'constants/urls';
+//import { DATA_UMBRELLA_URL } from 'constants/urls';
+import { DONATE_URL, DATA_UMBRELLA_URL } from 'constants/urls';
 import React from 'react';
 import ExternalLinkIcon from 'assets/ui/externalLink.svg'
 
@@ -24,7 +26,7 @@ function IntroductionSection() {
             Data Events Board
           </h1>
           <small className="italic text-du-purple-600 text-base font-medium  md:pl-36">
-            A <span className="underline">Data Umbrella</span> Initiative
+            A <a className="underline" href={DATA_UMBRELLA_URL} target="_blank" rel="noreferrer">Data Umbrella</a> Initiative
           </small>
         </div>
         <div>

--- a/src/constants/urls.js
+++ b/src/constants/urls.js
@@ -7,3 +7,4 @@ export const EVENTS_URL = `${API_URL}/api/v1/events`;
 export const CONTACT_EMAILS_URL = `${API_URL}/api/v1/contact_emails`;
 export const WEEKLY_DIGESTS_URL = `${API_URL}/api/v1/weekly_digests`;
 export const DONATE_URL = 'https://opencollective.com/data-umbrella/contribute/data-science-event-board-37473/checkout';
+export const DATA_UMBRELLA_URL = 'https://dataumbrella.org';


### PR DESCRIPTION
## PR Overview

#### Type of contribution
- [x] Code
- [ ] Documentation

#### Reference: Issue or Pull Request (PR)
- [ ] Towards #322   

## Description of Changes
In "A Data Umbrella Initiative", make "Data Umbrella" clickable.

## Before and After for UI Updates
<-- You should have 2 images minimum, for desktop, 4 for mobile and desktop combined -->

Before:

<img width="434" alt="Screen Shot 2023-01-12 at 12 24 21 PM" src="https://user-images.githubusercontent.com/2507232/212136521-934e6f1a-6e22-4bfe-b100-a2aa5f9dbd47.png">

After:
<img width="524" alt="Screen Shot 2023-01-12 at 12 24 43 PM" src="https://user-images.githubusercontent.com/2507232/212136589-2a1096b7-d737-410f-8d68-81b718789143.png">



## For PR Reviewer
- [ ] Does this file change the yarn.lock, package.json or package-lock.json file? If so, why?
- [ ] If this pr contains mobile and desktop changes, did you test on IphoneXr and desktop views?
- [ ] Does this file match the related tickets linked figma file, or does it pass the visual smell test?
- [ ] If this file contains javascript, does the javascript pass the smell test?
- [ ] If you don't feel super confident in your review, did you assign someone more senior to double check?

