### PR TITLE
mv event reg URL to top

### DIFF
--- a/src/components/elements/EventForm.jsx
+++ b/src/components/elements/EventForm.jsx
@@ -140,6 +140,17 @@ function PostEventFormComponent(props) {
             role="group"
             aria-labelledby="virtual-option-radio-group"
           >
+            <div className="mb-6">
+              <label htmlFor="eventRegistrationUrl">
+                Event Registration URL
+              </label>
+              <Field
+                autoComplete="new-password"
+                id="eventRegistrationUrl"
+                name="eventRegistrationUrl"
+                className={formStyleClasses.input}
+              />
+            </div>
             <div>
               <label className="mr-6">
                 <Field
@@ -397,17 +408,6 @@ function PostEventFormComponent(props) {
                 autoComplete="new-password"
                 id="codeOfConductUrl"
                 name="codeOfConductUrl"
-                className={formStyleClasses.input}
-              />
-            </div>
-            <div className="mb-6">
-              <label htmlFor="eventRegistrationUrl">
-                Event Registration URL
-              </label>
-              <Field
-                autoComplete="new-password"
-                id="eventRegistrationUrl"
-                name="eventRegistrationUrl"
                 className={formStyleClasses.input}
               />
             </div>


### PR DESCRIPTION
## PR Overview

#### Type of contribution
- [x] Code
- [ ] Documentation

#### Reference: Issue or Pull Request (PR)
- [ ] Closes #307   

## Description of Changes
Moved registration URL to top section of form

## Before and After for UI Updates
<-- You should have 2 images minimum, for desktop, 4 for mobile and desktop combined -->

Before:
<img width="998" alt="Screen Shot 2023-01-13 at 9 21 25 AM" src="https://user-images.githubusercontent.com/2507232/212341921-d0c5865e-d4bf-4cc2-8650-2f64a7d3d1f3.png">

After:

<img width="498" alt="Screen Shot 2023-01-13 at 9 21 07 AM" src="https://user-images.githubusercontent.com/2507232/212341965-021b7f31-73d0-43ce-ac2c-88cc076532aa.png">
<img width="1043" alt="Screen Shot 2023-01-13 at 9 19 53 AM" src="https://user-images.githubusercontent.com/2507232/212341967-8b441164-696c-41c9-9b96-58b1f028fade.png">

## For PR Reviewer
- [No] Does this file change the yarn.lock, package.json or package-lock.json file? If so, why?
- [x] If this PR contains mobile and desktop changes, did you test on IphoneXr and desktop views?
- [x] Does this file match the related tickets linked figma file, or does it pass the visual smell test?
- [x] If this file contains javascript, does the javascript pass the smell test?
- [x] If you don't feel super confident in your review, did you assign someone more senior to double check?

