### PR TITLE
Back to results feature

### DIFF
--- a/src/components/elements/ReviewEventMainSection.jsx
+++ b/src/components/elements/ReviewEventMainSection.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
 import { imageUrlForEvent } from 'utils/urls';
 import defaultThumbnail from 'assets/ui/thumbnail.png';
+import { useNavigate } from 'react-router-dom';
 
 const styleClasses = {
   mainSectionContainer: `
@@ -25,6 +25,7 @@ const styleClasses = {
 
 function ReviewEventMainSection({ evt, editEvent }) {
   const imageUrl = imageUrlForEvent(evt);
+  const navigate = useNavigate();
 
   const handleImageError = (event) => {
     event.target.src = defaultThumbnail;
@@ -34,7 +35,7 @@ function ReviewEventMainSection({ evt, editEvent }) {
     <section>
       <div className="mb-12">
         <p className="text-xl">
-          <Link to="/"> &#8592; Back to Results</Link>
+          <button onClick={() => navigate(-1)}>Back to Results</button>
         </p>
       </div>
 

--- a/src/components/elements/SearchForm.jsx
+++ b/src/components/elements/SearchForm.jsx
@@ -151,11 +151,11 @@ export function mapPropsToValues (props) {
     search: props.search,
     startDate: props.startDate,
     endDate: props.endDate,
-    price: props.price || '',
-    eventType: props.eventType || '',
-    topic: props.topic || '',
-    language: props.language || '',
-    region: props.region || '',
+    price: props.price,
+    eventType: props.eventType,
+    topic: props.topic,
+    language: props.language,
+    region: props.region,
   }
 }
 

--- a/src/components/elements/SearchForm.jsx
+++ b/src/components/elements/SearchForm.jsx
@@ -148,7 +148,7 @@ function SearchFormComponent({ clearFilters, setFieldValue, values }) {
  */
 export function mapPropsToValues (props) {
   return {
-    search: props.search || '',
+    search: props.search,
     startDate: props.startDate,
     endDate: props.endDate,
     price: props.price || '',

--- a/src/components/pages/HomePage.jsx
+++ b/src/components/pages/HomePage.jsx
@@ -35,6 +35,7 @@ function HomePage() {
         clearFilters={clearFilters}
         startDate={searchFilters.startDate}
         endDate={searchFilters.endDate}
+        search={searchFilters.search}
       />
       <SearchEvents
         events={results || []}

--- a/src/components/pages/HomePage.jsx
+++ b/src/components/pages/HomePage.jsx
@@ -35,7 +35,12 @@ function HomePage() {
         clearFilters={clearFilters}
         startDate={searchFilters.startDate}
         endDate={searchFilters.endDate}
+        eventType={searchFilters.eventType}
         search={searchFilters.search}
+        topic={searchFilters.topic}
+        language={searchFilters.language}
+        region={searchFilters.region}
+        price={searchFilters.price}
       />
       <SearchEvents
         events={results || []}

--- a/src/hooks/events.js
+++ b/src/hooks/events.js
@@ -71,14 +71,24 @@ export function useSearchEvents() {
   const page = searchParams.get('page') || 1;
   const startDate = searchParams.get('startDate') || moment().subtract(2, 'weeks').format(DATE_PICKER_STRING_FORMAT);
   const endDate = searchParams.get('endDate') || moment().add(6, 'months').format(DATE_PICKER_STRING_FORMAT);
-  const search = searchParams.get('search') 
+  const search = searchParams.get('search')
+  const eventType = searchParams.get('eventType') 
+  const topic = searchParams.get('topic')
+  const language = searchParams.get('language')
+  const price = searchParams.get('price')
+  const region = searchParams.get('region')
 
   const [searchFilters, setSearchFilters] = useState({
     startDate,
     endDate,
+    eventType,
     pageSize,
     page,
-    search
+    search,
+    topic,
+    language,
+    price,
+    region
   });
   const [searchResultEvents, setSearchResultEvents] = useState([]);
 

--- a/src/hooks/events.js
+++ b/src/hooks/events.js
@@ -118,6 +118,12 @@ export function useSearchEvents() {
       startDate: moment().subtract(2, 'weeks').format(DATE_PICKER_STRING_FORMAT),
       endDate: moment().add(5, 'months').format(DATE_PICKER_STRING_FORMAT),
       search: '',
+      eventType: '',
+      topic: '',
+      language: '',
+      price: '',
+      region: '',
+
     }
 
     setSearchFilters({ ...clearedFilters });

--- a/src/hooks/events.js
+++ b/src/hooks/events.js
@@ -71,12 +71,14 @@ export function useSearchEvents() {
   const page = searchParams.get('page') || 1;
   const startDate = searchParams.get('startDate') || moment().subtract(2, 'weeks').format(DATE_PICKER_STRING_FORMAT);
   const endDate = searchParams.get('endDate') || moment().add(6, 'months').format(DATE_PICKER_STRING_FORMAT);
+  const search = searchParams.get('search') 
+
   const [searchFilters, setSearchFilters] = useState({
     startDate,
     endDate,
-    search: '',
     pageSize,
     page,
+    search
   });
   const [searchResultEvents, setSearchResultEvents] = useState([]);
 


### PR DESCRIPTION
## PR Overview
When user applies a search in the search filter box, user should return to same filtered page when navigating between searches and specific event.

#### Type of contribution
- [x] Code
- [ ] Documentation

#### Reference: Issue or Pull Request (PR)
- [x] Towards #116   

## Description of Changes
HomePage searchForm params, SearchForm props, useNavigate for ReviewEventMainSection, events.js consts

## Before and After for UI Updates


Before:

https://user-images.githubusercontent.com/92892101/218827227-14bdd071-4169-4902-895d-6e1054cfc59c.mov

After:

https://user-images.githubusercontent.com/92892101/218826634-acf3a4d4-7cda-48f0-adfc-56a79a0ced7f.mov



## For PR Reviewer
- [ ] Does this file change the yarn.lock, package.json or package-lock.json file? If so, why?
- [ ] If this pr contains mobile and desktop changes, did you test on IphoneXr and desktop views?
- [ ] Does this file match the related tickets linked figma file, or does it pass the visual smell test?
- [ ] If this file contains javascript, does the javascript pass the smell test?
- [ ] If you don't feel super confident in your review, did you assign someone more senior to double check?

