### PR TITLE
Correct dark mode text

### DIFF
--- a/src/components/elements/EventCalendarView.jsx
+++ b/src/components/elements/EventCalendarView.jsx
@@ -36,7 +36,7 @@ function EventContent({ eventInfo }) {
                 <div className= "font-bold py-2">{eventInfo.event.title}</div>
                 <div className={`h-5 w-5 flex rounded-md bg-event-tags-${eventType}`}></div>
               </div>
-              <p className= "pb-4">{formattedStart} - {formattedEnd}</p>
+              <p className= "pb-4 dark:text-black">{formattedStart} - {formattedEnd}</p>
               <div className="event-tooltip-navigate cursor-pointer" onClick={handleNavigate}>{"Go to Event Page >>>"}</div>
             </>)
         }}/>


### PR DESCRIPTION
## PR Overview
Fixes  dark mode text in Event Calendar hover pop. 

#### Type of contribution
- [x] Code
- [ ] Documentation

#### Reference: Issue or Pull Request (PR)
- [ ] Towards #316  

## Description of Changes
EventCalendarView.jsx

## Before and After for UI Updates

Before:
<img width="500" alt="image" src="https://user-images.githubusercontent.com/92892101/222029314-13bf22ae-def1-4fd3-a12a-db0319f79871.png">

After:
<img width="500" alt="image" src="https://user-images.githubusercontent.com/92892101/222029413-89e8704c-e8dc-4dca-8bd2-2689b02537f8.png">


## For PR Reviewer
- [ ] Does this file change the yarn.lock, package.json or package-lock.json file? If so, why?
- [ ] If this pr contains mobile and desktop changes, did you test on IphoneXr and desktop views?
- [ ] Does this file match the related tickets linked figma file, or does it pass the visual smell test?
- [ ] If this file contains javascript, does the javascript pass the smell test?
- [ ] If you don't feel super confident in your review, did you assign someone more senior to double check?

