### PR TITLE
Fix featured events filter

### DIFF
--- a/src/__tests__/services/events.test.js
+++ b/src/__tests__/services/events.test.js
@@ -3,8 +3,11 @@ import {
   createEvent,
   updateEvent,
   submitEvent,
+  fetchFeaturedEvents,
 } from 'services/events'
 import { EVENTS_URL } from 'constants/urls';
+import dayjs from 'dayjs';
+import { DEFAULT_DATE_FORMAT } from 'constants/dates';
 
 describe('makeRequest', () => {
   let fetchMock;
@@ -52,11 +55,11 @@ describe('createEvent', () => {
 
   beforeEach(() => {
     fetchMock = jest.fn(() =>
-    Promise.resolve({
-      json: () => Promise.resolve(body),
-      status: 200,
-    })
-  );
+      Promise.resolve({
+        json: () => Promise.resolve(body),
+        status: 200,
+      })
+    );
     global.fetch = fetchMock;
   });
 
@@ -85,11 +88,11 @@ describe('updateEvent', () => {
 
   beforeEach(() => {
     fetchMock = jest.fn(() =>
-    Promise.resolve({
-      json: () => Promise.resolve(body),
-      status: 200,
-    })
-  );
+      Promise.resolve({
+        json: () => Promise.resolve(body),
+        status: 200,
+      })
+    );
     global.fetch = fetchMock;
   });
 
@@ -118,11 +121,11 @@ describe('submitEvent', () => {
 
   beforeEach(() => {
     fetchMock = jest.fn(() =>
-    Promise.resolve({
-      json: () => Promise.resolve({ ...body, submitted: true }),
-      status: 200,
-    })
-  );
+      Promise.resolve({
+        json: () => Promise.resolve({ ...body, submitted: true }),
+        status: 200,
+      })
+    );
     global.fetch = fetchMock;
   });
 
@@ -145,5 +148,39 @@ describe('submitEvent', () => {
       },
     );
     expect(response).toEqual({ ...body, submitted: true });
+  });
+});
+
+describe('fetchFeaturedEvents', () => {
+  let fetchMock;
+  let mockEvent = { id: 1, eventName: 'Test Event' };
+
+  beforeEach(() => {
+    fetchMock = jest.fn(() =>
+      Promise.resolve({
+        json: () => Promise.resolve([mockEvent]),
+        status: 200,
+      })
+    );
+    global.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    fetchMock.mockReset();
+    delete global.fetch;
+  });
+
+  it('sends a PATCH request to the events API', async () => {
+    const response = await fetchFeaturedEvents();
+    expect(fetchMock).toHaveBeenCalled();
+
+    const url = fetchMock.mock.calls[0][0];
+    const startDate = encodeURIComponent(dayjs().format(DEFAULT_DATE_FORMAT));
+    const endDate = encodeURIComponent(dayjs().add(5, 'month').format(DEFAULT_DATE_FORMAT));
+
+    expect(url).toContain(`${EVENTS_URL}?featured=true&published=true`);
+    expect(url).toContain(`start_date__gte=${startDate}`);
+    expect(url).toContain(`start_date__lte=${endDate}`);
+    expect(response).toEqual([mockEvent]);
   });
 });

--- a/src/services/events.js
+++ b/src/services/events.js
@@ -59,6 +59,7 @@ export function fetchEventResultsForSearchFilters(searchFilters) {
 export function fetchFeaturedEvents() {
   const query = queryString.stringify({
     featured: true,
+    published: true,
     start_date__gte: moment().format(DEFAULT_DATE_FORMAT),
     start_date__lte: moment().add(5, "months").format(DEFAULT_DATE_FORMAT),
   });


### PR DESCRIPTION
## PR Overview
Fixes an issue with unpublished events showing up in the featured events feed.

#### Type of contribution
- [X] Code
- [ ] Documentation

#### Reference: Issue or Pull Request (PR)
- [ ] Towards [#xxx   ](https://github.com/data-umbrella/event-board-web/issues/405)

## Description of Changes
<-- Brief description of the changes you made, files you touched, etc -->
Just needed to add the publish = true parameter to the API request.

## Before and After for UI Updates
The only visible difference is that unpublished events won't show up.

## For PR Reviewer
- [X] Does this file change the yarn.lock, package.json or package-lock.json file? If so, why?
- [X] If this pr contains mobile and desktop changes, did you test on IphoneXr and desktop views?
- [X] Does this file match the related tickets linked figma file, or does it pass the visual smell test?
- [X] If this file contains javascript, does the javascript pass the smell test?
- [X] If you don't feel super confident in your review, did you assign someone more senior to double check?

