### PR TITLE
fix: weekly digest into email digest

### DIFF
--- a/src/__tests__/components/pages/WeeklyDigestPage.test.jsx
+++ b/src/__tests__/components/pages/WeeklyDigestPage.test.jsx
@@ -9,11 +9,11 @@ jest.mock('hooks/authentication', () => ({
   }),
 }));
 
-describe('Weekly digest sign up', () => {
+describe('Email digest sign up', () => {
   it('renders heading', () => {
     render(<WeeklyDigestPage />);
 
-    expect(screen.getByText(/Subscribe to our Weekly Digest/i))
+    expect(screen.getByText(/Subscribe to our Email Digest/i))
       .toBeInTheDocument();
   });
 });

--- a/src/components/elements/AppRoutes.jsx
+++ b/src/components/elements/AppRoutes.jsx
@@ -69,7 +69,7 @@ function AppRoutes() {
           </RequireAuth>
         }
       />
-      <Route path="/events/weekly-digest" element={<WeeklyDigestPage />} />
+      <Route path="/events/email-digest" element={<WeeklyDigestPage />} />
       <Route
         path="/events/:eventId/review"
         element={

--- a/src/components/elements/MobileNav.jsx
+++ b/src/components/elements/MobileNav.jsx
@@ -84,7 +84,7 @@ function MobileNav() {
             )}
             <Link to="/events/calendar">Event Calendar</Link><br />
             <Link to="/events/new">Post Event</Link><br/>
-            <Link to="/events/weekly-digest">Weekly Digest</Link><br/>
+            <Link to="/events/email-digest">Email Digest</Link><br/>
             <Link to="/sponsors">Sponsors</Link><br/>
             <a href={DONATE_URL} target="_blank" rel="noreferrer">Donate</a><br/>
             <Link to="/about">About Us</Link><br/>

--- a/src/components/elements/NavigationBar.jsx
+++ b/src/components/elements/NavigationBar.jsx
@@ -110,10 +110,10 @@ function NavigationBar() {
             </div>
             <div>
               <a
-                href="/events/weekly-digest"
+                href="/events/email-digest"
                 className={navStyleClasses.navLink}
               >
-                Weekly Digest
+                Email Digest
               </a>
             </div>
             <div>

--- a/src/components/pages/WeeklyDigestPage.jsx
+++ b/src/components/pages/WeeklyDigestPage.jsx
@@ -137,7 +137,7 @@ function WeeklyDigestPage() {
       <ToastContainer />
       <div className="xs:mb-40 lg:mt-12 lg:mx-28 xl:mx-40">
         <div className="container mx-auto text-center">
-          <h2 className="font-bold text-lg md:pt-12 lg:text-4xl lg:pb-3 text-left lg:text-center">Subscribe to our Weekly Digest</h2>
+          <h2 className="font-bold text-lg md:pt-12 lg:text-4xl lg:pb-3 text-left lg:text-center">Subscribe to our Email Digest</h2>
           <h3 className="text-left lg:text-center">Sign up to learn about upcoming Data Science events.</h3>
         </div>  
         <p className="pt-4 text-red-700 text-center">{subscribedStatus}</p>

--- a/src/constants/navbar.js
+++ b/src/constants/navbar.js
@@ -1,7 +1,7 @@
 export const NAVBAR_EVENT_OPTIONS = [
   { label: 'Event Calendar', value: 'event-calendar', route: '/events/calendar' },
   { label: 'Post Event', value: 'post-event', route: '/events/new' },
-  { label: 'Weekly Digest', value: 'weekly-digest', route: '/events/weekly-digest' },
+  { label: 'Email Digest', value: 'weekly-digest', route: '/events/email-digest' },
 ]
   
 export const NAVBAR_SUPPORT_OPTIONS = [


### PR DESCRIPTION
## PR Overview

#### Type of contribution
- [x] Code
- [ ] Documentation

#### Reference: Issue or Pull Request (PR)
- [x] Towards #412  

## Description of Changes
"Weekly Digest" menu item: change to "Email Digest" throughout the website and route name also changed into the same.

## Before and After for UI Updates
<-- You should have 2 images minimum, for desktop, 4 for mobile and desktop combined -->

Before:
![image](https://github.com/data-umbrella/event-board-web/assets/93966956/6216de73-2212-4d9e-99b2-ee4ad5c7a1a1)

After:
![image](https://github.com/data-umbrella/event-board-web/assets/93966956/16c0cdc2-23ae-4ae0-befe-08c8e1885a7f)


## For PR Reviewer
- [ ] Does this file change the yarn.lock, package.json or package-lock.json file? If so, why?
- [x] If this pr contains mobile and desktop changes, did you test on IphoneXr and desktop views?
- [ ] Does this file match the related tickets linked figma file, or does it pass the visual smell test?
- [ ] If this file contains javascript, does the javascript pass the smell test?
- [ ] If you don't feel super confident in your review, did you assign someone more senior to double check?

